### PR TITLE
Change workshop id type to string

### DIFF
--- a/MWVideoGridPlugin/MWVideoGridPlugin/VideoGridStep/MWNetworkVideoGridStep.swift
+++ b/MWVideoGridPlugin/MWVideoGridPlugin/VideoGridStep/MWNetworkVideoGridStep.swift
@@ -19,12 +19,12 @@ class MWNetworkVideoGridStep: ORKStep, VideoGridStep, RemoteContentStep, Syncabl
     let stepContext: StepContext
     let session: Session
     let services: MobileWorkflowServices
-    let secondaryWorkflowIDs: [Int]
+    let secondaryWorkflowIDs: [String]
     var contentURL: String? { self.url }
     var resolvedURL: URL?
     var items: [VideoGridStepItem] = []
     
-    init(identifier: String, stepInfo: StepInfo, services: MobileWorkflowServices, secondaryWorkflowIDs: [Int], url: String? = nil, emptyText: String? = nil) {
+    init(identifier: String, stepInfo: StepInfo, services: MobileWorkflowServices, secondaryWorkflowIDs: [String], url: String? = nil, emptyText: String? = nil) {
         self.stepContext = stepInfo.context
         self.session = stepInfo.session
         self.services = services
@@ -65,7 +65,7 @@ extension MWNetworkVideoGridStep: MobileWorkflowStep {
         
         let url = step.data.content["url"] as? String
         let emptyText = services.localizationService.translate(step.data.content["emptyText"] as? String)
-        let secondaryWorkflowIDs: [Int] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0["id"] as? Int }) ?? []
+        let secondaryWorkflowIDs: [String] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0.getString(key: "id") }) ?? []
         
         let step = MWNetworkVideoGridStep(
             identifier: step.data.identifier,

--- a/MWVideoGridPlugin/MWVideoGridPlugin/VideoGridStep/MWVideoGridStep.swift
+++ b/MWVideoGridPlugin/MWVideoGridPlugin/VideoGridStep/MWVideoGridStep.swift
@@ -12,10 +12,10 @@ public class MWVideoGridStep: ORKStep, VideoGridStep {
     
     let session: Session
     let services: MobileWorkflowServices
-    public let secondaryWorkflowIDs: [Int]
+    public let secondaryWorkflowIDs: [String]
     let items: [VideoGridStepItem]
     
-    init(identifier: String, session: Session, services: MobileWorkflowServices, secondaryWorkflowIDs: [Int], items: [VideoGridStepItem]) {
+    init(identifier: String, session: Session, services: MobileWorkflowServices, secondaryWorkflowIDs: [String], items: [VideoGridStepItem]) {
         self.session = session
         self.services = services
         self.secondaryWorkflowIDs = secondaryWorkflowIDs
@@ -36,7 +36,7 @@ extension MWVideoGridStep: MobileWorkflowStep {
     
     public static func build(step: StepInfo, services: MobileWorkflowServices) throws -> ORKStep {
         
-        let secondaryWorkflowIDs: [Int] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0["id"] as? Int }) ?? []
+        let secondaryWorkflowIDs: [String] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0.getString(key: "id") }) ?? []
         let contentItems = step.data.content["items"] as? [[String: Any]] ?? []
         let items: [VideoGridStepItem] = try contentItems.compactMap {
             guard let text = services.localizationService.translate($0["text"] as? String) else { return nil }

--- a/MWVideoGridPlugin/MWVideoGridPlugin/VideoGridStep/MWVideoGridViewController.swift
+++ b/MWVideoGridPlugin/MWVideoGridPlugin/VideoGridStep/MWVideoGridViewController.swift
@@ -32,7 +32,7 @@ class MWVideoGridViewController: ORKStepViewController, HasSecondaryWorkflows {
         return (self.step as? VideoGridStep)
     }
     
-    var secondaryWorkflowIDs: [Int] {
+    var secondaryWorkflowIDs: [String] {
         return self.videoGridStep.secondaryWorkflowIDs
     }
     


### PR DESCRIPTION
With the latest change in the core to have workshop ID as a string, this plugin needs to be updated to match the new interfaces.