### PR TITLE
[MW-1028] Buttons as stack items

### DIFF
--- a/MWContentDisplay/MWContentDisplay/App Configuration/app.json
+++ b/MWContentDisplay/MWContentDisplay/App Configuration/app.json
@@ -153,7 +153,8 @@
                         {
                             "id": "9",
                             "label": "Book Session",
-                            "type": "button"
+                            "type": "button",
+                            "onSuccess": "backward"
                         }
                     ],
                     "optional": false,

--- a/MWContentDisplay/MWContentDisplay/App Configuration/app.json
+++ b/MWContentDisplay/MWContentDisplay/App Configuration/app.json
@@ -149,6 +149,11 @@
                             "imageURL": "https://source.unsplash.com/biX8sBfNcPc/800x600",
                             "text": "Yoga Mat (optional)",
                             "type": "listItem"
+                        },
+                        {
+                            "id": "9",
+                            "title": "Book Session",
+                            "type": "button"
                         }
                     ],
                     "optional": false,

--- a/MWContentDisplay/MWContentDisplay/App Configuration/app.json
+++ b/MWContentDisplay/MWContentDisplay/App Configuration/app.json
@@ -152,7 +152,7 @@
                         },
                         {
                             "id": "9",
-                            "title": "Book Session",
+                            "label": "Book Session",
                             "type": "button"
                         }
                     ],

--- a/MWContentDisplay/MWContentDisplay/App Configuration/app.json
+++ b/MWContentDisplay/MWContentDisplay/App Configuration/app.json
@@ -5,7 +5,17 @@
     "name": "Xavi - ContentDisplayPlugin NEW UI",
     "navigationStyle": "tab_bar",
     "navigationWorkflow1Id": "0de2acc8-d6cf-41c7-937d-bd41730d5af2",
-    "servers": [],
+    "navigationWorkflow2Id": "606ae0ee-9629-4868-b54f-6a4161fdd8f3",
+    "networkService": {
+        "properties": {},
+        "type": "io.mobileworkflow.OAuthRestAsyncService"
+    },
+    "servers": [
+        {
+            "id": 527,
+            "url": "https://039ad388-6bfc-4673-9b17-93dc53b02e02.mock.pstmn.io"
+        }
+    ],
     "systemTintColor": "blue",
     "workflows": [
         {
@@ -149,18 +159,71 @@
                             "imageURL": "https://source.unsplash.com/biX8sBfNcPc/800x600",
                             "text": "Yoga Mat (optional)",
                             "type": "listItem"
-                        },
-                        {
-                            "id": "9",
-                            "label": "Book Session",
-                            "type": "button",
-                            "onSuccess": "backward"
                         }
                     ],
                     "optional": false,
                     "title": "Yoga for Beginners",
                     "type": "io.mobileworkflow.ContentStack",
                     "uuid": "ec3f631b-70f1-4f52-8ff2-1d99cb930e96"
+                }
+            ]
+        },
+        {
+            "id": "606ae0ee-9629-4868-b54f-6a4161fdd8f3",
+            "identifier": "From Network",
+            "materialIconName": "",
+            "name": "From Network",
+            "navigationRules": [
+                {
+                    "from": "test",
+                    "rules": [
+                        {
+                            "to": "from_network"
+                        }
+                    ]
+                },
+                {
+                    "from": "from_network",
+                    "rules": [
+                        {
+                            "to": "ORKNullStepIdentifier"
+                        }
+                    ]
+                }
+            ],
+            "sfSymbolName": "",
+            "steps": [
+                {
+                    "identifier": "test",
+                    "items": [
+                        {
+                            "id": "1",
+                            "text": "Tap anything",
+                            "type": "largeSection"
+                        },
+                        {
+                            "id": "2",
+                            "text": "First Item",
+                            "type": "item"
+                        },
+                        {
+                            "id": "3",
+                            "text": "Second Item",
+                            "type": "item"
+                        }
+                    ],
+                    "optional": false,
+                    "title": "Test",
+                    "type": "videoGrid",
+                    "uuid": "885cef5b-253e-49fa-bc4b-4a709268176f"
+                },
+                {
+                    "identifier": "from_network",
+                    "optional": false,
+                    "title": "From Network",
+                    "type": "io.mobileworkflow.NetworkStyledStack",
+                    "url": "/whatever/{test.selected.id}",
+                    "uuid": "5ddfda2d-8489-4fb0-afc3-bbb6b863073e"
                 }
             ]
         }

--- a/MWContentDisplay/MWContentDisplay/SceneDelegate.swift
+++ b/MWContentDisplay/MWContentDisplay/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: MWSceneDelegate {
     override func preferredConfigurations(urlContexts: Set<UIOpenURLContext>) -> [AppConfigurationContext] {
         var preferredConfigurations = [AppConfigurationContext]()
         if let filePath = Bundle.main.path(forResource: "app", ofType: "json") {
-            preferredConfigurations.append(.file(path: filePath, serverId: 418, workflowId: nil, sessionValues: nil))
+            preferredConfigurations.append(.file(path: filePath, serverId: 527, workflowId: nil, sessionValues: nil))
         }
         return preferredConfigurations
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackStep.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackStep.swift
@@ -11,13 +11,9 @@ import MobileWorkflowCore
 public class MWStackStep: MWStep {
     
     var contents: MWStackStepContents
-    let session: Session
-    let services: StepServices
     
-    init(identifier: String, contents: MWStackStepContents, session: Session, services: StepServices) {
+    init(identifier: String, contents: MWStackStepContents) {
         self.contents = contents
-        self.session = session
-        self.services = services
         super.init(identifier: identifier)
     }
     
@@ -37,9 +33,7 @@ extension MWStackStep: BuildableStep {
         
         if stepInfo.data.type == MWContentDisplayStepType.stack.typeName {
             return MWStackStep(identifier: stepInfo.data.identifier,
-                               contents: contents,
-                               session: stepInfo.session,
-                               services: services)
+                               contents: contents)
         } else if stepInfo.data.type == MWContentDisplayStepType.networkStack.typeName {
             return MWNetworkStackStep(identifier: stepInfo.data.identifier,
                                       contentURLString: stepInfo.data.content["url"] as? String,

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackStep.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackStep.swift
@@ -11,9 +11,13 @@ import MobileWorkflowCore
 public class MWStackStep: MWStep {
     
     var contents: MWStackStepContents
+    let session: Session
+    let services: StepServices
     
-    init(identifier: String, contents: MWStackStepContents) {
+    init(identifier: String, contents: MWStackStepContents, session: Session, services: StepServices) {
         self.contents = contents
+        self.session = session
+        self.services = services
         super.init(identifier: identifier)
     }
     
@@ -33,7 +37,9 @@ extension MWStackStep: BuildableStep {
         
         if stepInfo.data.type == MWContentDisplayStepType.stack.typeName {
             return MWStackStep(identifier: stepInfo.data.identifier,
-                               contents: contents)
+                               contents: contents,
+                               session: stepInfo.session,
+                               services: services)
         } else if stepInfo.data.type == MWContentDisplayStepType.networkStack.typeName {
             return MWNetworkStackStep(identifier: stepInfo.data.identifier,
                                       contentURLString: stepInfo.data.content["url"] as? String,

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -9,16 +9,19 @@ import UIKit
 import SwiftUI
 import MobileWorkflowCore
 
-public class MWStackViewController: MWStepViewController {
+public class MWStackViewController: MWStepViewController, SuccessActionHandler {
     
+    //MARK: Properties
     var contentStackStep: MWStackStep { self.mwStep as! MWStackStep }
     var hostingController: UIHostingController<MWStackView>? = nil
     
+    //MARK: Lifecycle
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.installSwiftUIView()
     }
     
+    // MARK: Methods
     func installSwiftUIView() {
         if let previousHostingController = self.hostingController {
             self.removeCovering(childViewController: previousHostingController)
@@ -26,8 +29,8 @@ public class MWStackViewController: MWStepViewController {
         
         let swiftUIRootView = MWStackView(contents: self.contentStackStep.contents, backButtonTapped: { [weak self] in
             self?.handleBackButtonTapped()
-        }, buttonTapped: { buttonItem in
-            print("Tapped \(buttonItem.label)")
+        }, buttonTapped: { [weak self] item in
+            self?.handleButtonItemTapped(item)
         })
         self.hostingController = UIHostingController(rootView: swiftUIRootView)
         self.addCovering(childViewController: self.hostingController!)
@@ -40,6 +43,27 @@ public class MWStackViewController: MWStepViewController {
             if let target = self.cancelButtonItem?.target, let action = self.cancelButtonItem?.action {
                 UIApplication.shared.sendAction(action, to: target, from: nil, for: nil)
             }
+        }
+    }
+    
+    func handleButtonItemTapped(_ item: MWStackStepItemButton) {
+        //TODO: Do something and then call handleSuccessAction
+        print("Tapped: \(item.label)")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            self.handleSuccessAction(item.sucessAction)
+        }
+    }
+    
+    //MARK: SuccessActionHandler
+    public func handleSuccessAction(_ action: SuccessAction) {
+        switch action {
+        case .none: break
+        case .forward: self.goForward()
+        case .backward: self.goBackward()
+        case .reload: self.installSwiftUIView()
+        @unknown default:
+            fatalError("Unhandled action: \(action.rawValue)")
         }
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -57,7 +57,10 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
                 }
             }
         } else if let remoteURL = item.remoteURL, let httpMethod = item.remoteURLMethod {
-            //TODO: Perform the request and call success
+            self.performRequest(to: remoteURL, usingHTTPMethod: httpMethod) { result in
+                //TODO: Handle result
+                dump(result)
+            }
         } else if let systemURL = item.systemURL {
             do {
                 try self.performSystemAction(systemURL.absoluteString)
@@ -66,6 +69,30 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
             }
         } else {
             self.handleSuccessAction(item.sucessAction)
+        }
+    }
+    
+    func performRequest(to url: URL, usingHTTPMethod httpMethod: HTTPMethod, completion: @escaping (Result<Data, Error>) -> Void) {
+        guard let url = self.contentStackStep.session.resolve(url: url.absoluteString) else {
+            return completion(.failure(URLError(.badURL)))
+        }
+        do {
+            let credential = try self.contentStackStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get()
+            let task = URLAsyncTask<Data?>.build(url: url,
+                                          method: httpMethod,
+                                          body: nil,
+                                          session: self.contentStackStep.session,
+                                          credential: credential,
+                                          headers: [:]) { data in
+                //TODO: Parse the response
+                throw ParseError.invalidAppData(cause: "UNHANDLED")
+            }
+            self.contentStackStep.services.perform(task: task, session: self.contentStackStep.session) { result in
+                //TODO: Handle result
+                dump(result)
+            }
+        } catch (let error) {
+            completion(.failure(error))
         }
     }
     
@@ -81,4 +108,3 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
         }
     }
 }
-

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -27,7 +27,7 @@ public class MWStackViewController: MWStepViewController {
         let swiftUIRootView = MWStackView(contents: self.contentStackStep.contents, backButtonTapped: { [weak self] in
             self?.handleBackButtonTapped()
         }, buttonTapped: { buttonItem in
-            print("Tapped \(buttonItem.title ?? "")")
+            print("Tapped \(buttonItem.label)")
         })
         self.hostingController = UIHostingController(rootView: swiftUIRootView)
         self.addCovering(childViewController: self.hostingController!)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -9,7 +9,10 @@ import UIKit
 import SwiftUI
 import MobileWorkflowCore
 
-public class MWStackViewController: MWStepViewController, SuccessActionHandler {
+public class MWStackViewController: MWStepViewController, WorkflowPresentationDelegator, SuccessActionHandler {
+    
+    //MARK: Public properties (WorkflowPresentationDelegator)
+    public weak var workflowPresentationDelegate: WorkflowPresentationDelegate?
     
     //MARK: Properties
     var contentStackStep: MWStackStep { self.mwStep as! MWStackStep }
@@ -47,8 +50,16 @@ public class MWStackViewController: MWStepViewController, SuccessActionHandler {
     }
     
     func handleButtonItemTapped(_ item: MWStackStepItemButton) {
-        if let remoteURL = item.remoteURL {
+        if let modalWorkflow = item.modalWorkflow {
+            self.workflowPresentationDelegate?.presentWorkflowWithName(modalWorkflow, isDiscardable: true, animated: true) { [weak self] reason in
+                if reason == .completed {
+                    self?.handleSuccessAction(item.sucessAction)
+                }
+            }
+        } else if let remoteURL = item.remoteURL, let httpMethod = item.remoteURLMethod {
             //TODO: Perform the request and call success
+        } else if let systemURL = item.systemURL {
+            //TODO: Open the system URL
         } else {
             self.handleSuccessAction(item.sucessAction)
         }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -56,11 +56,6 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
                     self?.handleSuccessAction(item.sucessAction)
                 }
             }
-        } else if let remoteURL = item.remoteURL, let httpMethod = item.remoteURLMethod {
-            self.performRequest(to: remoteURL, usingHTTPMethod: httpMethod) { result in
-                //TODO: Handle result
-                dump(result)
-            }
         } else if let systemURL = item.systemURL {
             do {
                 try self.performSystemAction(systemURL.absoluteString)
@@ -69,30 +64,6 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
             }
         } else {
             self.handleSuccessAction(item.sucessAction)
-        }
-    }
-    
-    func performRequest(to url: URL, usingHTTPMethod httpMethod: HTTPMethod, completion: @escaping (Result<Data, Error>) -> Void) {
-        guard let url = self.contentStackStep.session.resolve(url: url.absoluteString) else {
-            return completion(.failure(URLError(.badURL)))
-        }
-        do {
-            let credential = try self.contentStackStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get()
-            let task = URLAsyncTask<Data?>.build(url: url,
-                                          method: httpMethod,
-                                          body: nil,
-                                          session: self.contentStackStep.session,
-                                          credential: credential,
-                                          headers: [:]) { data in
-                //TODO: Parse the response
-                throw ParseError.invalidAppData(cause: "UNHANDLED")
-            }
-            self.contentStackStep.services.perform(task: task, session: self.contentStackStep.session) { result in
-                //TODO: Handle result
-                dump(result)
-            }
-        } catch (let error) {
-            completion(.failure(error))
         }
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -59,7 +59,11 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
         } else if let remoteURL = item.remoteURL, let httpMethod = item.remoteURLMethod {
             //TODO: Perform the request and call success
         } else if let systemURL = item.systemURL {
-            //TODO: Open the system URL
+            do {
+                try self.performSystemAction(systemURL.absoluteString)
+            } catch {
+                self.show(error)
+            }
         } else {
             self.handleSuccessAction(item.sucessAction)
         }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -47,10 +47,9 @@ public class MWStackViewController: MWStepViewController, SuccessActionHandler {
     }
     
     func handleButtonItemTapped(_ item: MWStackStepItemButton) {
-        //TODO: Do something and then call handleSuccessAction
-        print("Tapped: \(item.label)")
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        if let remoteURL = item.remoteURL {
+            //TODO: Perform the request and call success
+        } else {
             self.handleSuccessAction(item.sucessAction)
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -16,8 +16,18 @@ public class MWStackViewController: MWStepViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        self.installSwiftUIView()
+    }
+    
+    func installSwiftUIView() {
+        if let previousHostingController = self.hostingController {
+            self.removeCovering(childViewController: previousHostingController)
+        }
+        
         let swiftUIRootView = MWStackView(contents: self.contentStackStep.contents, backButtonTapped: { [weak self] in
             self?.handleBackButtonTapped()
+        }, buttonTapped: { buttonItem in
+            print("Tapped \(buttonItem.title ?? "")")
         })
         self.hostingController = UIHostingController(rootView: swiftUIRootView)
         self.addCovering(childViewController: self.hostingController!)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -132,7 +132,7 @@ struct MWStackStepItemButton: Identifiable {
     
     // Action: Perform a request to the given URL
     let remoteURL: URL?
-    let remoteURLMethod: String?
+    let remoteURLMethod: HTTPMethod?
     
     // Action: Open the URL to the system
     let systemURL: URL?
@@ -153,7 +153,7 @@ struct MWStackStepItemButton: Identifiable {
         self.label = localizationService.translate(json["label"] as? String) ?? ""
         self.modalWorkflow = json["modalWorkflow"] as? String
         self.remoteURL = (json["url"] as? String).flatMap{ URL(string: $0) }
-        self.remoteURLMethod = json["method"] as? String
+        self.remoteURLMethod = (json["method"] as? String).flatMap{HTTPMethod(rawValue: $0.uppercased())}
         self.systemURL = (json["appleSystemURL"] as? String).flatMap{ URL(string: $0) }
         self.sucessAction = SuccessAction(rawValue: json["onSuccess"] as? String ?? "") ?? .none
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -125,7 +125,8 @@ struct MWStackStepStepItemListItem: Identifiable {
 
 struct MWStackStepItemButton: Identifiable {
     let id: String
-    let title: String?
+    let label: String
+    let sucessAction: SuccessAction
     
     init?(json: [String:Any], localizationService: LocalizationService) {
         guard (json["type"] as? String) == Optional("button") else {
@@ -137,6 +138,7 @@ struct MWStackStepItemButton: Identifiable {
         }
         
         self.id = id
-        self.title = localizationService.translate(json["title"] as? String)
+        self.label = localizationService.translate(json["label"] as? String) ?? ""
+        self.sucessAction = SuccessAction(rawValue: json["onSuccess"] as? String ?? "") ?? .none
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -126,6 +126,7 @@ struct MWStackStepStepItemListItem: Identifiable {
 struct MWStackStepItemButton: Identifiable {
     let id: String
     let label: String
+    let remoteURL: URL?
     let sucessAction: SuccessAction
     
     init?(json: [String:Any], localizationService: LocalizationService) {
@@ -139,6 +140,7 @@ struct MWStackStepItemButton: Identifiable {
         
         self.id = id
         self.label = localizationService.translate(json["label"] as? String) ?? ""
+        self.remoteURL = (json["url"] as? String).flatMap{ URL(string: $0) }
         self.sucessAction = SuccessAction(rawValue: json["onSuccess"] as? String ?? "") ?? .none
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -31,12 +31,14 @@ enum MWStackStepItem: Identifiable {
     case title(MWStackStepItemTitle)
     case text(MWStackStepItemText)
     case listItem(MWStackStepStepItemListItem)
+    case button(MWStackStepItemButton)
     
     public var id: String {
         switch self {
         case .title(let item): return item.id
         case .text(let item): return item.id
         case .listItem(let item): return item.id
+        case .button(let item): return item.id
         }
     }
     
@@ -47,6 +49,8 @@ enum MWStackStepItem: Identifiable {
             self = .text(stepTypeText)
         } else if let stepTypeListItem = MWStackStepStepItemListItem(json: json, localizationService: localizationService) {
             self = .listItem(stepTypeListItem)
+        } else if let stepTypeButtom = MWStackStepItemButton(json: json, localizationService: localizationService) {
+            self = .button(stepTypeButtom)
         } else {
             return nil
         }
@@ -116,5 +120,23 @@ struct MWStackStepStepItemListItem: Identifiable {
         } else {
             self.imageURL = nil
         }
+    }
+}
+
+struct MWStackStepItemButton: Identifiable {
+    let id: String
+    let title: String?
+    
+    init?(json: [String:Any], localizationService: LocalizationService) {
+        guard (json["type"] as? String) == Optional("button") else {
+            return nil
+        }
+        guard let id = json["id"] as? String else {
+            assertionFailure("Missing id.")
+            return nil
+        }
+        
+        self.id = id
+        self.title = localizationService.translate(json["title"] as? String)
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -126,7 +126,18 @@ struct MWStackStepStepItemListItem: Identifiable {
 struct MWStackStepItemButton: Identifiable {
     let id: String
     let label: String
+        
+    // Action: Open a modal workflow
+    let modalWorkflow: String?
+    
+    // Action: Perform a request to the given URL
     let remoteURL: URL?
+    let remoteURLMethod: String?
+    
+    // Action: Open the URL to the system
+    let systemURL: URL?
+    
+    // What to do after performing the action
     let sucessAction: SuccessAction
     
     init?(json: [String:Any], localizationService: LocalizationService) {
@@ -140,7 +151,10 @@ struct MWStackStepItemButton: Identifiable {
         
         self.id = id
         self.label = localizationService.translate(json["label"] as? String) ?? ""
+        self.modalWorkflow = json["modalWorkflow"] as? String
         self.remoteURL = (json["url"] as? String).flatMap{ URL(string: $0) }
+        self.remoteURLMethod = json["method"] as? String
+        self.systemURL = (json["appleSystemURL"] as? String).flatMap{ URL(string: $0) }
         self.sucessAction = SuccessAction(rawValue: json["onSuccess"] as? String ?? "") ?? .none
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackStep.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackStep.swift
@@ -16,16 +16,12 @@ class MWNetworkStackStep: MWStackStep, RemoteContentStep, SyncableContentSource 
     
     // Remote Content
     var stepContext: StepContext
-    var session: Session
-    var services: StepServices
     var contentURL: String?
     
     init(identifier: String, contentURLString: String?, contents: MWStackStepContents, stepContext: StepContext, session: Session, services: StepServices) {
         self.stepContext = stepContext
-        self.session = session
-        self.services = services
         self.contentURL = contentURLString
-        super.init(identifier: identifier, contents: contents)
+        super.init(identifier: identifier, contents: contents, session: session, services: services)
     }
     
     required init(coder aDecoder: NSCoder) {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackStep.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackStep.swift
@@ -10,6 +10,9 @@ import MobileWorkflowCore
 
 class MWNetworkStackStep: MWStackStep, RemoteContentStep, SyncableContentSource {
     
+    let session: Session
+    let services: StepServices
+    
     // Syncable Content
     typealias ResponseType = MWStackStepContents
     var resolvedURL: URL?
@@ -19,9 +22,11 @@ class MWNetworkStackStep: MWStackStep, RemoteContentStep, SyncableContentSource 
     var contentURL: String?
     
     init(identifier: String, contentURLString: String?, contents: MWStackStepContents, stepContext: StepContext, session: Session, services: StepServices) {
+        self.session = session
+        self.services = services
         self.stepContext = stepContext
         self.contentURL = contentURLString
-        super.init(identifier: identifier, contents: contents, session: session, services: services)
+        super.init(identifier: identifier, contents: contents)
     }
     
     required init(coder aDecoder: NSCoder) {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
@@ -17,7 +17,6 @@ class MWNetworkStackViewController: MWStackViewController, RemoteContentStepView
     
     //MARK: Properties
     var remoteContentStep: MWNetworkStackStep! { self.mwStep as? MWNetworkStackStep }
-    weak var workflowPresentationDelegate: WorkflowPresentationDelegate?
 
     //MARK: Lifecycle
     override func viewDidLoad() {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
@@ -43,17 +43,9 @@ class MWNetworkStackViewController: MWStackViewController, RemoteContentStepView
     }
     
     func update(content: MWStackStepContents) {
-        if let previousHostingController = self.hostingController {
-            self.removeCovering(childViewController: previousHostingController)
-        }
-        
         self.remoteContentStep.contents = content
         
-        let swiftUIRootView = MWStackView(contents: self.remoteContentStep.contents, backButtonTapped: { [weak self] in
-            self?.handleBackButtonTapped()
-        })
-        self.hostingController = UIHostingController(rootView: swiftUIRootView)
-        self.addCovering(childViewController: self.hostingController!)
+        self.installSwiftUIView()
         
         if content.items.isEmpty {
             self.stateView.configure(isLoading: false, title: L10n.noContent, subtitle: nil, buttonConfig: nil)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
@@ -68,18 +68,18 @@ class MWNetworkStackViewController: MWStackViewController, RemoteContentStepView
     }
     
     private func performButtonRemoteRequest(to url: URL, usingHTTPMethod httpMethod: HTTPMethod, successAction: SuccessAction) {
-        guard let url = self.contentStackStep.session.resolve(url: url.absoluteString) else { return }
+        guard let url = self.remoteContentStep.session.resolve(url: url.absoluteString) else { return }
         // Only PUT/DELETE are supported on buttons
         guard httpMethod == .PUT || httpMethod == .DELETE else { return }
         do {
-            let credential = try self.contentStackStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get()
-            let task = URLAsyncTask<MWStackStepContents>.build(url: url, method: httpMethod, session: self.contentStackStep.session, credential: credential, headers: [:]) { data -> MWStackStepContents in
+            let credential = try self.remoteContentStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get()
+            let task = URLAsyncTask<MWStackStepContents>.build(url: url, method: httpMethod, session: self.remoteContentStep.session, credential: credential, headers: [:]) { data -> MWStackStepContents in
                 guard let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String:Any] else {
                     throw ParseError.invalidServerData(cause: "Unexpected JSON format.")
                 }
-                return MWStackStepContents(json: json, localizationService: self.contentStackStep.services.localizationService)
+                return MWStackStepContents(json: json, localizationService: self.remoteContentStep.services.localizationService)
             }
-            self.contentStackStep.services.perform(task: task, session: self.contentStackStep.session) { [weak self] result in
+            self.remoteContentStep.services.perform(task: task, session: self.remoteContentStep.session) { [weak self] result in
                 guard let self = self else { return }
                 switch result {
                 case .success(let newContents):

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -118,7 +118,7 @@ fileprivate struct MWButtonView: View {
         Button {
             tapped(item)
         } label: {
-            Text(item.title ?? "")
+            Text(item.label)
                 .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))
                 .frame(maxWidth: .infinity, idealHeight: 50, maxHeight: 50, alignment: .center)
                 .foregroundColor(.white)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -120,7 +120,7 @@ fileprivate struct MWButtonView: View {
                 .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))
                 .frame(maxWidth: .infinity, idealHeight: 50, maxHeight: 50, alignment: .center)
                 .foregroundColor(.white)
-                .background(Color.blue)
+                .background(Color(UIColor.systemBlue))
                 .cornerRadius(16)
         }.padding(EdgeInsets(top: 24, leading: 0, bottom: 24, trailing: 0))
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -113,8 +113,15 @@ fileprivate struct MWButtonView: View {
     let item: MWStackStepItemButton
     
     var body: some View {
-        Button(item.title ?? "") {
+        Button {
             print("Tapped")
-        }
+        } label: {
+            Text(item.title ?? "")
+                .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))
+                .frame(maxWidth: .infinity, idealHeight: 50, maxHeight: 50, alignment: .center)
+                .foregroundColor(.white)
+                .background(Color.blue)
+                .cornerRadius(16)
+        }.padding(EdgeInsets(top: 24, leading: 0, bottom: 24, trailing: 0))
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -44,6 +44,7 @@ struct MWStackView: View {
                 case .title(let innerItem): MWTitleView(item: innerItem)
                 case .text(let innerItem): MWTextView(item: innerItem).padding(EdgeInsets(top: 0, leading: 0, bottom: 24, trailing: 0))
                 case .listItem(let innerItem): MWListItemView(stepTypeListItem: innerItem)
+                case .button(let innerItem): MWButtonView(item: innerItem)
                 }
             }
         }
@@ -104,5 +105,16 @@ fileprivate struct MWListItemView: View {
         RoundedRectangle(cornerRadius: 8)
             .fill(Color.gray)
             .frame(width: 48, height: 48, alignment: .center)
+    }
+}
+
+fileprivate struct MWButtonView: View {
+    
+    let item: MWStackStepItemButton
+    
+    var body: some View {
+        Button(item.title ?? "") {
+            print("Tapped")
+        }
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -13,6 +13,7 @@ struct MWStackView: View {
     
     var contents: MWStackStepContents
     var backButtonTapped: () -> Void
+    var buttonTapped: (MWStackStepItemButton) -> Void
     
     var body: some View {
         self.makeScrollView()
@@ -44,7 +45,7 @@ struct MWStackView: View {
                 case .title(let innerItem): MWTitleView(item: innerItem)
                 case .text(let innerItem): MWTextView(item: innerItem).padding(EdgeInsets(top: 0, leading: 0, bottom: 24, trailing: 0))
                 case .listItem(let innerItem): MWListItemView(stepTypeListItem: innerItem)
-                case .button(let innerItem): MWButtonView(item: innerItem)
+                case .button(let innerItem): MWButtonView(item: innerItem, tapped: buttonTapped)
                 }
             }
         }
@@ -111,10 +112,11 @@ fileprivate struct MWListItemView: View {
 fileprivate struct MWButtonView: View {
     
     let item: MWStackStepItemButton
+    var tapped: (MWStackStepItemButton) -> Void
     
     var body: some View {
         Button {
-            print("Tapped")
+            tapped(item)
         } label: {
             Text(item.title ?? "")
                 .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -122,7 +122,7 @@ fileprivate struct MWButtonView: View {
                 .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))
                 .frame(maxWidth: .infinity, idealHeight: 50, maxHeight: 50, alignment: .center)
                 .foregroundColor(.white)
-                .background(Color(UIColor.systemBlue))
+                .background(item.remoteURLMethod == Optional(.DELETE) ? Color(UIColor.systemRed) :Color(UIColor.systemBlue))
                 .cornerRadius(16)
         }.padding(EdgeInsets(top: 24, leading: 0, bottom: 24, trailing: 0))
     }


### PR DESCRIPTION
This PR adds support for buttons that have actions. The possible actions are:
- Single tap
- Present a modal workflow
- Open a system URL (to settings for example)
- Perform a PUT or DELETE requests to a given URL

Once any of those actions are performed, the following options can happen on completion:
- Nothing
- Move forward
- Move backwards
- Reload