### PR TITLE
Styled stack updates

### DIFF
--- a/MWContentDisplayPlugin/MWContentDisplayPlugin.xcodeproj/project.pbxproj
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		628EC3A6255E9F7B00CD1992 /* MWContentDisplayPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 628EC39C255E9F7A00CD1992 /* MWContentDisplayPlugin.framework */; };
 		628EC3AB255E9F7B00CD1992 /* MWVideoGridPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628EC3AA255E9F7B00CD1992 /* MWVideoGridPluginTests.swift */; };
 		628EC3AD255E9F7B00CD1992 /* MWContentDisplayPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 628EC39F255E9F7A00CD1992 /* MWContentDisplayPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ADE0F1172681CFE9000D6E9D /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE0F1162681CFE9000D6E9D /* CloseButton.swift */; };
 		B10669EF261C5E21005878DB /* MWStackStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10669EE261C5E21005878DB /* MWStackStep.swift */; };
 		B10669F3261C5EBA005878DB /* MWStackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10669F2261C5EBA005878DB /* MWStackViewController.swift */; };
 		B10F833A261F569D005BAEC3 /* MWStackStepContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F8339261F569D005BAEC3 /* MWStackStepContents.swift */; };
@@ -68,6 +69,7 @@
 		628EC3AC255E9F7B00CD1992 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A600D4D57ADA58E1BC5B629 /* Pods_MWContentDisplayPluginTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MWContentDisplayPluginTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		980A44E52379947BB8387DB1 /* Pods-MWVideoGridPluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MWVideoGridPluginTests.debug.xcconfig"; path = "Target Support Files/Pods-MWVideoGridPluginTests/Pods-MWVideoGridPluginTests.debug.xcconfig"; sourceTree = "<group>"; };
+		ADE0F1162681CFE9000D6E9D /* CloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseButton.swift; sourceTree = "<group>"; };
 		B10669EE261C5E21005878DB /* MWStackStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MWStackStep.swift; sourceTree = "<group>"; };
 		B10669F2261C5EBA005878DB /* MWStackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MWStackViewController.swift; sourceTree = "<group>"; };
 		B10F8339261F569D005BAEC3 /* MWStackStepContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MWStackStepContents.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 			children = (
 				B1E25425263848400084A44D /* FancyScrollView.swift */,
 				B1E2542A263848400084A44D /* HeaderScrollView.swift */,
+				ADE0F1162681CFE9000D6E9D /* CloseButton.swift */,
 				B1E2542B263848400084A44D /* AppleMusicStyleScrollView.swift */,
 				B1E25428263848400084A44D /* BackButton.swift */,
 				B1E2542C263848400084A44D /* HeaderScrollViewTitle.swift */,
@@ -458,6 +461,7 @@
 				367CB765264E93DF00ADFC79 /* MWNetworkGridStepViewController.swift in Sources */,
 				B10F8342261F5C99005BAEC3 /* MWNetworkStackStep.swift in Sources */,
 				B1E25437263848400084A44D /* ScrollUpHeaderBehavior.swift in Sources */,
+				ADE0F1172681CFE9000D6E9D /* CloseButton.swift in Sources */,
 				B10F833A261F569D005BAEC3 /* MWStackStepContents.swift in Sources */,
 				B1E25431263848400084A44D /* BlurView.swift in Sources */,
 				B1E25438263848400084A44D /* View+navigationAllowSpipeBackWhenHidden.swift in Sources */,

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -22,6 +22,7 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
     var contentStackStep: MWStackStep { self.mwStep as! MWStackStep }
     var hostingController: UIHostingController<MWStackView>? = nil
     
+    // Enable per default. Will only be shown if back button is disabled.
     private var isCloseButtonEnabled: Bool {
         return true
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -22,6 +22,14 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
     var contentStackStep: MWStackStep { self.mwStep as! MWStackStep }
     var hostingController: UIHostingController<MWStackView>? = nil
     
+    private var isBackButtonEnabled: Bool {
+        if let navController = self.navigationController {
+            return navController.viewControllers.count > 1
+        } else {
+            return false
+        }
+    }
+    
     //MARK: Lifecycle
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,7 +51,8 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
             self?.handleBackButtonTapped()
         }, buttonTapped: { [weak self] item in
             self?.handleButtonItemTapped(item)
-        }, tintColor: self.contentStackStep.tintColor)
+        }, tintColor: self.contentStackStep.tintColor,
+        isBackButtonEnabled: self.isBackButtonEnabled)
         self.hostingController = UIHostingController(rootView: swiftUIRootView)
         self.addCovering(childViewController: self.hostingController!)
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -14,6 +14,10 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
     //MARK: Public properties (WorkflowPresentationDelegator)
     public weak var workflowPresentationDelegate: WorkflowPresentationDelegate?
     
+    public override var titleMode: StepViewControllerTitleMode {
+        .customOrNone
+    }
+    
     //MARK: Properties
     var contentStackStep: MWStackStep { self.mwStep as! MWStackStep }
     var hostingController: UIHostingController<MWStackView>? = nil
@@ -35,7 +39,7 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
             self.removeCovering(childViewController: previousHostingController)
         }
         
-        let swiftUIRootView = MWStackView(contents: self.contentStackStep.contents, backButtonTapped: { [weak self] in
+        let swiftUIRootView = MWStackView(screenSize: self.view.frame.size, contents: self.contentStackStep.contents, backButtonTapped: { [weak self] in
             self?.handleBackButtonTapped()
         }, buttonTapped: { [weak self] item in
             self?.handleButtonItemTapped(item)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -22,6 +22,10 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
     var contentStackStep: MWStackStep { self.mwStep as! MWStackStep }
     var hostingController: UIHostingController<MWStackView>? = nil
     
+    private var isCloseButtonEnabled: Bool {
+        return true
+    }
+    
     private var isBackButtonEnabled: Bool {
         if let navController = self.navigationController {
             return navController.viewControllers.count > 1
@@ -52,6 +56,7 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
         }, buttonTapped: { [weak self] item in
             self?.handleButtonItemTapped(item)
         }, tintColor: self.contentStackStep.tintColor,
+        isCloseButtonEnabled: self.isCloseButtonEnabled,
         isBackButtonEnabled: self.isBackButtonEnabled)
         self.hostingController = UIHostingController(rootView: swiftUIRootView)
         self.addCovering(childViewController: self.hostingController!)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/CloseButton.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/CloseButton.swift
@@ -1,0 +1,34 @@
+//
+//  CloseButton.swift
+//  MWContentDisplayPlugin
+//
+//  Created by Eric Sans on 22/6/21.
+//
+
+import SwiftUI
+
+struct CloseButton: View {
+    let color: Color
+    
+    var closeButtonTapped: () -> Void
+
+    var body: some View {
+        Button(action: { self.closeButtonTapped() }) {
+            ZStack {
+                Rectangle()
+                    .frame(width: 44, height: 44)
+                    .foregroundColor(Color(red: 28/255, green: 28/255, blue: 30/255))
+                    .cornerRadius(12)
+                    .padding(.horizontal, 16)
+                    .opacity(0.4)
+                Image(systemName: "xmark")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 20, alignment: .leading)
+                    .foregroundColor(color)
+                    .padding(.horizontal, 16)
+                    .font(Font.body.bold())
+            }
+        }
+    }
+}

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/FancyScrollView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/FancyScrollView.swift
@@ -10,6 +10,7 @@ public struct FancyScrollView: View {
     let header: AnyView?
     let content: AnyView
     
+    let isCloseButtonEnabled: Bool
     let isBackButtonEnabled: Bool
     var backButtonTapped: () -> Void
 
@@ -23,6 +24,7 @@ public struct FancyScrollView: View {
                                  header: header,
                                  content: content,
                                  isBackButtonEnabled: isBackButtonEnabled,
+                                 isCloseButtonEnabled: isCloseButtonEnabled,
                                  backButtonTapped: self.backButtonTapped)
             )
         } else {
@@ -57,6 +59,7 @@ extension FancyScrollView {
                                   scrollDownHeaderBehavior: ScrollDownHeaderBehavior = .offset,
                                   header: () -> A?,
                                   content: () -> B,
+                                  isCloseButtonEnabled: Bool,
                                   isBackButtonEnabled: Bool,
                                   backButtonTapped: @escaping () -> Void) {
 
@@ -66,6 +69,7 @@ extension FancyScrollView {
                   scrollDownHeaderBehavior: scrollDownHeaderBehavior,
                   header: AnyView(header()),
                   content: AnyView(content()),
+                  isCloseButtonEnabled: isCloseButtonEnabled,
                   isBackButtonEnabled: isBackButtonEnabled,
                   backButtonTapped: backButtonTapped)
     }
@@ -75,6 +79,7 @@ extension FancyScrollView {
                          scrollUpHeaderBehavior: ScrollUpHeaderBehavior = .parallax,
                          scrollDownHeaderBehavior: ScrollDownHeaderBehavior = .offset,
                          content: () -> A,
+                         isCloseButtonEnabled: Bool,
                          isBackButtonEnabled: Bool,
                          backButtonTapped: @escaping () -> Void) {
 
@@ -84,6 +89,7 @@ extension FancyScrollView {
                      scrollDownHeaderBehavior: scrollDownHeaderBehavior,
                      header: nil,
                      content: AnyView(content()),
+                     isCloseButtonEnabled: isCloseButtonEnabled,
                      isBackButtonEnabled: isBackButtonEnabled,
                      backButtonTapped: backButtonTapped)
        }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/FancyScrollView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/FancyScrollView.swift
@@ -10,6 +10,7 @@ public struct FancyScrollView: View {
     let header: AnyView?
     let content: AnyView
     
+    let isBackButtonEnabled: Bool
     var backButtonTapped: () -> Void
 
     public var body: some View {
@@ -21,6 +22,7 @@ public struct FancyScrollView: View {
                                  scrollDownBehavior: scrollDownHeaderBehavior,
                                  header: header,
                                  content: content,
+                                 isBackButtonEnabled: isBackButtonEnabled,
                                  backButtonTapped: self.backButtonTapped)
             )
         } else {
@@ -55,6 +57,7 @@ extension FancyScrollView {
                                   scrollDownHeaderBehavior: ScrollDownHeaderBehavior = .offset,
                                   header: () -> A?,
                                   content: () -> B,
+                                  isBackButtonEnabled: Bool,
                                   backButtonTapped: @escaping () -> Void) {
 
         self.init(title: title,
@@ -63,6 +66,7 @@ extension FancyScrollView {
                   scrollDownHeaderBehavior: scrollDownHeaderBehavior,
                   header: AnyView(header()),
                   content: AnyView(content()),
+                  isBackButtonEnabled: isBackButtonEnabled,
                   backButtonTapped: backButtonTapped)
     }
 
@@ -71,6 +75,7 @@ extension FancyScrollView {
                          scrollUpHeaderBehavior: ScrollUpHeaderBehavior = .parallax,
                          scrollDownHeaderBehavior: ScrollDownHeaderBehavior = .offset,
                          content: () -> A,
+                         isBackButtonEnabled: Bool,
                          backButtonTapped: @escaping () -> Void) {
 
            self.init(title: title,
@@ -79,6 +84,7 @@ extension FancyScrollView {
                      scrollDownHeaderBehavior: scrollDownHeaderBehavior,
                      header: nil,
                      content: AnyView(content()),
+                     isBackButtonEnabled: isBackButtonEnabled,
                      backButtonTapped: backButtonTapped)
        }
 

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
@@ -2,6 +2,11 @@ import SwiftUI
 
 private let navigationBarHeight: CGFloat = 44
 
+// NavigationBarHeight is also used to provide:
+// - offset BlurView
+// - padding for back button
+// - padding for title header
+
 struct HeaderScrollView: View {
     @Environment(\.colorScheme)
     private var colorScheme: ColorScheme
@@ -38,13 +43,13 @@ struct HeaderScrollView: View {
                             ZStack {
                                 BlurView()
                                     .opacity(1 - sqrt(geometry.largeTitleWeight))
-                                    .offset(y: geometry.blurOffset + 40)
+                                    .offset(y: geometry.blurOffset + navigationBarHeight)
 
                                 VStack {
                                     if isBackButtonEnabled {
                                         geometry.largeTitleWeight == 1 ? HStack {
                                             BackButton(color: .white, backButtonTapped: self.backButtonTapped)
-                                                .padding(.top, -40)
+                                                .padding(.top, -navigationBarHeight)
                                             Spacer()
                                         }.frame(width: geometry.width, height: navigationBarHeight) : nil
                                     }
@@ -57,7 +62,7 @@ struct HeaderScrollView: View {
                                                           isBackButtonEnabled: isBackButtonEnabled)
                                         .layoutPriority(1000)
                                 }
-                                .padding(.top, globalGeometry.safeAreaInsets.top + 80)
+                                .padding(.top, globalGeometry.safeAreaInsets.top + navigationBarHeight * 2)
                                 .frame(width: geometry.width, height: max(geometry.elementsHeight, navigationBarHeight))
                                 .offset(y: geometry.elementsOffset)
                             }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
@@ -13,6 +13,7 @@ struct HeaderScrollView: View {
     let header: AnyView
     let content: AnyView
     
+    let isBackButtonEnabled: Bool
     var backButtonTapped: () -> Void
 
     var body: some View {
@@ -40,17 +41,21 @@ struct HeaderScrollView: View {
                                     .offset(y: geometry.blurOffset + 40)
 
                                 VStack {
-                                    geometry.largeTitleWeight == 1 ? HStack {
-                                        BackButton(color: .white, backButtonTapped: self.backButtonTapped)
-                                            .padding(.top, -40)
-                                        Spacer()
-                                    }.frame(width: geometry.width, height: navigationBarHeight) : nil
-
+                                    if isBackButtonEnabled {
+                                        geometry.largeTitleWeight == 1 ? HStack {
+                                            BackButton(color: .white, backButtonTapped: self.backButtonTapped)
+                                                .padding(.top, -40)
+                                            Spacer()
+                                        }.frame(width: geometry.width, height: navigationBarHeight) : nil
+                                    }
                                     Spacer()
 
                                     HeaderScrollViewTitle(title: self.title,
                                                           height: navigationBarHeight,
-                                                          largeTitle: geometry.largeTitleWeight, backButtonTapped: self.backButtonTapped).layoutPriority(1000)
+                                                          largeTitle: geometry.largeTitleWeight,
+                                                          backButtonTapped: self.backButtonTapped,
+                                                          isBackButtonEnabled: isBackButtonEnabled)
+                                        .layoutPriority(1000)
                                 }
                                 .padding(.top, globalGeometry.safeAreaInsets.top + 80)
                                 .frame(width: geometry.width, height: max(geometry.elementsHeight, navigationBarHeight))

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
@@ -37,11 +37,12 @@ struct HeaderScrollView: View {
                             ZStack {
                                 BlurView()
                                     .opacity(1 - sqrt(geometry.largeTitleWeight))
-                                    .offset(y: geometry.blurOffset)
+                                    .offset(y: geometry.blurOffset + 40)
 
                                 VStack {
                                     geometry.largeTitleWeight == 1 ? HStack {
                                         BackButton(color: .white, backButtonTapped: self.backButtonTapped)
+                                            .padding(.top, -40)
                                         Spacer()
                                     }.frame(width: geometry.width, height: navigationBarHeight) : nil
 
@@ -51,7 +52,7 @@ struct HeaderScrollView: View {
                                                           height: navigationBarHeight,
                                                           largeTitle: geometry.largeTitleWeight, backButtonTapped: self.backButtonTapped).layoutPriority(1000)
                                 }
-                                .padding(.top, globalGeometry.safeAreaInsets.top)
+                                .padding(.top, globalGeometry.safeAreaInsets.top + 80)
                                 .frame(width: geometry.width, height: max(geometry.elementsHeight, navigationBarHeight))
                                 .offset(y: geometry.elementsOffset)
                             }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollView.swift
@@ -19,6 +19,7 @@ struct HeaderScrollView: View {
     let content: AnyView
     
     let isBackButtonEnabled: Bool
+    let isCloseButtonEnabled: Bool
     var backButtonTapped: () -> Void
 
     var body: some View {
@@ -52,6 +53,12 @@ struct HeaderScrollView: View {
                                                 .padding(.top, -navigationBarHeight)
                                             Spacer()
                                         }.frame(width: geometry.width, height: navigationBarHeight) : nil
+                                    } else if isCloseButtonEnabled {
+                                        geometry.largeTitleWeight == 1 ? HStack {
+                                            Spacer()
+                                            CloseButton(color: .white, closeButtonTapped: self.backButtonTapped)
+                                                .padding(.top, -navigationBarHeight)
+                                        }.frame(width: geometry.width, height: navigationBarHeight) : nil
                                     }
                                     Spacer()
 
@@ -59,6 +66,7 @@ struct HeaderScrollView: View {
                                                           height: navigationBarHeight,
                                                           largeTitle: geometry.largeTitleWeight,
                                                           backButtonTapped: self.backButtonTapped,
+                                                          isCloseButtonEnabled: isCloseButtonEnabled,
                                                           isBackButtonEnabled: isBackButtonEnabled)
                                         .layoutPriority(1000)
                                 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollViewTitle.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollViewTitle.swift
@@ -6,6 +6,7 @@ struct HeaderScrollViewTitle: View {
     let largeTitle: Double
     var backButtonTapped: () -> Void
     
+    let isCloseButtonEnabled: Bool
     let isBackButtonEnabled: Bool
     
     @Environment(\.colorScheme)
@@ -37,6 +38,11 @@ struct HeaderScrollViewTitle: View {
                     HStack {
                         BackButton(color: .primary, backButtonTapped: self.backButtonTapped)
                         Spacer()
+                    }
+                } else if isCloseButtonEnabled {
+                    HStack {
+                        Spacer()
+                        CloseButton(color: .primary, closeButtonTapped: self.backButtonTapped)
                     }
                 }
                 HStack {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollViewTitle.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollViewTitle.swift
@@ -7,6 +7,9 @@ struct HeaderScrollViewTitle: View {
     var backButtonTapped: () -> Void
     
     let isBackButtonEnabled: Bool
+    
+    @Environment(\.colorScheme)
+    private var colorScheme: ColorScheme
 
     var body: some View {
         let largeTitleOpacity = (max(largeTitle, 0.5) - 0.5) * 2
@@ -20,9 +23,9 @@ struct HeaderScrollViewTitle: View {
 
                 Spacer()
             }
-            .padding(.bottom, 8)
+            .padding(.bottom, 16)
             .background(
-                LinearGradient(gradient: Gradient(colors: [.clear, Color(UIColor(red: 28/255, green: 28/255, blue: 28/255, alpha: 0.8))]), startPoint: .top, endPoint: .bottom)
+                self.makeLinearGradient()
                     .frame(height: 80)
                     .offset(y: -18)
             )
@@ -46,5 +49,13 @@ struct HeaderScrollViewTitle: View {
             .padding(.bottom, (height - 18) / 2)
             .opacity(sqrt(tinyTitleOpacity))
         }.frame(height: height)
+    }
+    
+    private func makeLinearGradient() -> LinearGradient {
+        if colorScheme == .dark {
+            return LinearGradient(gradient: Gradient(colors: [.clear, Color(UIColor(red: 28/255, green: 28/255, blue: 28/255, alpha: 0.8))]), startPoint: .top, endPoint: .bottom)
+        } else {
+            return LinearGradient(gradient: Gradient(colors: [.clear, Color(UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1.0))]), startPoint: .top, endPoint: .bottom)
+        }
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollViewTitle.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/FancyScrollView/HeaderScrollViewTitle.swift
@@ -5,6 +5,8 @@ struct HeaderScrollViewTitle: View {
     let height: CGFloat
     let largeTitle: Double
     var backButtonTapped: () -> Void
+    
+    let isBackButtonEnabled: Bool
 
     var body: some View {
         let largeTitleOpacity = (max(largeTitle, 0.5) - 0.5) * 2
@@ -28,9 +30,11 @@ struct HeaderScrollViewTitle: View {
             .minimumScaleFactor(0.5)
 
             ZStack {
-                HStack {
-                    BackButton(color: .primary, backButtonTapped: self.backButtonTapped)
-                    Spacer()
+                if isBackButtonEnabled {
+                    HStack {
+                        BackButton(color: .primary, backButtonTapped: self.backButtonTapped)
+                        Spacer()
+                    }
                 }
                 HStack {
                     Text(title)

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -11,6 +11,7 @@ import Foundation
 
 struct MWStackView: View {
     
+    var screenSize: CGSize
     var contents: MWStackStepContents
     var backButtonTapped: () -> Void
     var buttonTapped: (MWStackStepItemButton) -> Void
@@ -18,6 +19,7 @@ struct MWStackView: View {
     
     var body: some View {
         self.makeScrollView()
+            .frame(width: screenSize.width, height: screenSize.height + 70, alignment: .top)
     }
     
     private func makeScrollView() -> some View {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import Kingfisher
 import Foundation
 
+// Without this padding, header will not expand to the top of the screen.
+private let topPadding: CGFloat = 44
+
 struct MWStackView: View {
     
     var screenSize: CGSize
@@ -21,7 +24,7 @@ struct MWStackView: View {
     
     var body: some View {
         self.makeScrollView()
-            .frame(width: screenSize.width, height: screenSize.height + 70, alignment: .top)
+            .frame(width: screenSize.width, height: screenSize.height + topPadding, alignment: .top)
     }
     
     private func makeScrollView() -> some View {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -17,6 +17,8 @@ struct MWStackView: View {
     var buttonTapped: (MWStackStepItemButton) -> Void
     var tintColor: UIColor
     
+    let isBackButtonEnabled: Bool
+    
     var body: some View {
         self.makeScrollView()
             .frame(width: screenSize.width, height: screenSize.height + 70, alignment: .top)
@@ -33,11 +35,13 @@ struct MWStackView: View {
                     .aspectRatio(contentMode: .fill)
             }, content: {
                 self.makeContentScrollView()
-            }, backButtonTapped: self.backButtonTapped)
+            }, isBackButtonEnabled: isBackButtonEnabled,
+            backButtonTapped: self.backButtonTapped)
         } else {
             return FancyScrollView(content: {
                 self.makeContentScrollView()
-            }, backButtonTapped: self.backButtonTapped)
+            }, isBackButtonEnabled: isBackButtonEnabled,
+            backButtonTapped: self.backButtonTapped)
         }
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -10,7 +10,7 @@ import Kingfisher
 import Foundation
 
 // Without this padding, header will not expand to the top of the screen.
-private let topPadding: CGFloat = 44
+private let topPadding: CGFloat = 100
 
 struct MWStackView: View {
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -20,6 +20,7 @@ struct MWStackView: View {
     var buttonTapped: (MWStackStepItemButton) -> Void
     var tintColor: UIColor
     
+    let isCloseButtonEnabled: Bool
     let isBackButtonEnabled: Bool
     
     var body: some View {
@@ -38,12 +39,14 @@ struct MWStackView: View {
                     .aspectRatio(contentMode: .fill)
             }, content: {
                 self.makeContentScrollView()
-            }, isBackButtonEnabled: isBackButtonEnabled,
+            }, isCloseButtonEnabled: isCloseButtonEnabled,
+            isBackButtonEnabled: isBackButtonEnabled,
             backButtonTapped: self.backButtonTapped)
         } else {
             return FancyScrollView(content: {
                 self.makeContentScrollView()
-            }, isBackButtonEnabled: isBackButtonEnabled,
+            }, isCloseButtonEnabled: isCloseButtonEnabled,
+            isBackButtonEnabled: isBackButtonEnabled,
             backButtonTapped: self.backButtonTapped)
         }
     }


### PR DESCRIPTION
- Fix popping presentation by setting size of the view to HostingViewController's height + topPadding to prevent empty space in the top of the screen while pushing the controller.
- Remove back button for scenarios where StackView is a main screen and not pushed.
- Change title gradient for `lightMode`.