### PR TITLE
Add URL Link button

### DIFF
--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWStackViewController.swift
@@ -54,8 +54,8 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
         
         let swiftUIRootView = MWStackView(screenSize: self.view.frame.size, contents: self.contentStackStep.contents, backButtonTapped: { [weak self] in
             self?.handleBackButtonTapped()
-        }, buttonTapped: { [weak self] item in
-            self?.handleButtonItemTapped(item)
+        }, buttonTapped: { [weak self] item, rect in
+            self?.handleButtonItemTapped(item, in: rect)
         }, tintColor: self.contentStackStep.tintColor,
         isCloseButtonEnabled: self.isCloseButtonEnabled,
         isBackButtonEnabled: self.isBackButtonEnabled)
@@ -73,7 +73,7 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
         }
     }
     
-    func handleButtonItemTapped(_ item: MWStackStepItemButton) {
+    func handleButtonItemTapped(_ item: MWStackStepItemButton, in rect: CGRect) {
         if let modalWorkflow = item.modalWorkflow {
             self.workflowPresentationDelegate?.presentWorkflowWithName(modalWorkflow, isDiscardable: true, animated: true) { [weak self] reason in
                 if reason == .completed {
@@ -86,7 +86,10 @@ public class MWStackViewController: MWStepViewController, WorkflowPresentationDe
             } catch {
                 self.show(error)
             }
-        } else {
+        } else if let linkURL = item.linkURL {
+            self.presentActivitySheet(with: [linkURL], sourceRect: rect)
+        }
+        else {
             self.handleSuccessAction(item.sucessAction)
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -140,6 +140,9 @@ struct MWStackStepItemButton: Identifiable {
     // Action: Open the URL to the system
     let systemURL: URL?
     
+    // Sharable Link
+    let linkURL: URL?
+    
     // What to do after performing the action
     let sucessAction: SuccessAction
     
@@ -157,6 +160,7 @@ struct MWStackStepItemButton: Identifiable {
         self.remoteURL = (json["url"] as? String).flatMap{ URL(string: $0) }
         self.remoteURLMethod = (json["method"] as? String).flatMap{HTTPMethod(rawValue: $0.uppercased())}
         self.systemURL = (json["appleSystemURL"] as? String).flatMap{ URL(string: $0) }
+        self.linkURL = (json["linkURL"] as? String).flatMap{ URL(string: $0) }
         self.sucessAction = SuccessAction(rawValue: json["onSuccess"] as? String ?? "") ?? .none
         self.sfSymbolName = (json["sfSymbolName"] as? String)
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
@@ -59,11 +59,11 @@ class MWNetworkStackViewController: MWStackViewController, RemoteContentStepView
         self.stateView.configure(isLoading: false, title: nil, subtitle: nil, buttonConfig: nil)
     }
     
-    override func handleButtonItemTapped(_ item: MWStackStepItemButton) {
+    override func handleButtonItemTapped(_ item: MWStackStepItemButton, in rect: CGRect) {
         if let remoteURL = item.remoteURL, let httpMethod = item.remoteURLMethod {
             self.performButtonRemoteRequest(to: remoteURL, usingHTTPMethod: httpMethod, successAction: item.sucessAction)
         } else {
-            super.handleButtonItemTapped(item)
+            super.handleButtonItemTapped(item, in: rect)
         }
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -63,7 +63,7 @@ struct MWStackView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .padding(EdgeInsets(top: 24, leading: 16, bottom: 24, trailing: 16))
+        .padding(EdgeInsets(top: 24, leading: 16, bottom: 84, trailing: 16))
     }
 }
 

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -73,6 +73,7 @@ fileprivate struct MWTitleView: View {
         
     var body: some View {
         Text(item.title).font(Font(UIFont.preferredFont(forTextStyle: .title3, weight: .bold)))
+            .fixedSize(horizontal: false, vertical: true)
     }
 }
 
@@ -82,6 +83,7 @@ fileprivate struct MWTextView: View {
         
     var body: some View {
         Text(item.text).font(.body)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -17,7 +17,7 @@ struct MWStackView: View {
     var screenSize: CGSize
     var contents: MWStackStepContents
     var backButtonTapped: () -> Void
-    var buttonTapped: (MWStackStepItemButton) -> Void
+    var buttonTapped: (MWStackStepItemButton, CGRect) -> Void
     var tintColor: UIColor
     
     let isCloseButtonEnabled: Bool
@@ -128,23 +128,27 @@ fileprivate struct MWListItemView: View {
 fileprivate struct MWButtonView: View {
     
     let item: MWStackStepItemButton
-    var tapped: (MWStackStepItemButton) -> Void
+    var tapped: (_ item: MWStackStepItemButton, _ rect: CGRect) -> Void
     var systemTintColor: Color
     
     var body: some View {
-        Button {
-            tapped(item)
-        } label: {
-            HStack(spacing: 4) {
-                if let systemName = item.sfSymbolName {
-                    Image(systemName: systemName)
+        // Needs GeometryReader to send back the frame of the button for popOver purposes
+        GeometryReader { geo in
+            Button {
+                tapped(item, geo.frame(in: .global))
+            } label: {
+                HStack(spacing: 4) {
+                    if let systemName = item.sfSymbolName {
+                        Image(systemName: systemName)
+                    }
+                    Text(item.label)
+                        .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))
+                        .lineLimit(1)
                 }
-                Text(item.label)
-                    .font(Font(UIFont.preferredFont(forTextStyle: .body, weight: .bold)))
-                    .lineLimit(1)
+                .frame(maxWidth: .infinity, idealHeight: 44, maxHeight: 44, alignment: .center)
             }
-            .frame(maxWidth: .infinity, idealHeight: 44, maxHeight: 44, alignment: .center)
         }
+        .frame(maxWidth: .infinity, idealHeight: 44, maxHeight: 44, alignment: .center)
         .buttonStyle(MWButtonStyle(style: item.style, systemTintColor: systemTintColor))
         .padding(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
     }


### PR DESCRIPTION
Add `linkURL` property to buttons, to handle a sharable URL using `ActivityViewController`.

- Include `rect` in callback, to correctly handle popovers on iPad