### PR TITLE
'Go backwards' after dismissing network stack error

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.0.3'
+    s.version               = '1.0.4'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkStackViewController.swift
@@ -36,7 +36,7 @@ class MWNetworkStackViewController: MWStackViewController, RemoteContentStepView
             self?.hideLoading()
             switch result {
             case .success(let items): self?.update(content: items)
-            case .failure(let error): self?.show(error)
+            case .failure(let error): self?.show(error) { [weak self] in self?.goBackward() }
             }
         }
     }


### PR DESCRIPTION
This is to prevent the user from getting stuck on a blank screen.