### PR TITLE
Updated navBar hiding behaviour

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.0.5'
+    s.version               = '1.0.6'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -40,7 +40,6 @@ class MWGridStepViewController: MWStepViewController, HasSecondaryWorkflows {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
         self.update(items: self.gridStep.items)
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
@@ -20,7 +20,7 @@ public class MWContentDisplayStackViewController: MWStepViewController, Workflow
     
     // Hide Navigation Bar
     public override func configureNavigationBar(_ navigationBar: UINavigationBar) {
-        navigationBar.isHidden = true
+        navigationBar.isHidden = true // navBars are now re-shown by default, so we shouldn't need to worry about subsequent steps
     }
     
     //MARK: Properties
@@ -37,22 +37,14 @@ public class MWContentDisplayStackViewController: MWStepViewController, Workflow
     }
     
     private var isBackButtonEnabled: Bool {
-        if let navController = self.navigationController {
-            return navController.viewControllers.count > 1
-        } else {
-            return false
-        }
+        let shouldHideBackButton = self.mwDelegate?.mwStepViewControllerShouldHideBackButton(self) ?? false
+        return !shouldHideBackButton
     }
     
     //MARK: Lifecycle
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.installSwiftUIView()
-    }
-    
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
     
     // MARK: Methods


### PR DESCRIPTION
- The core will now re-show hidden navBars on step appearance by default, so this update removes superfluous hide/show calls.
- Also now using step delegate `mwStepViewControllerShouldHideBackButton(:)` to determine if styled stack navBar button is hidden/shown, instead of using own logic.