### PR TITLE
Bug/network response handling

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.0.7'
+    s.version               = '1.0.8'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -14,6 +14,12 @@ struct MWStackStepContents {
     let headerImageURL: URL?
     let items: [MWStackStepItem]
     
+    init(headerTitle: String? = nil, headerImageURL: URL? = nil, items: [MWStackStepItem]){
+        self.headerTitle = headerTitle
+        self.headerImageURL = headerImageURL
+        self.items = items
+    }
+    
     init(json: [String:Any], localizationService: LocalizationService) {
         self.headerTitle = localizationService.translate(json["title"] as? String)
         self.headerImageURL = (json["imageURL"] as? String).flatMap{ URL(string: $0) }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -36,7 +36,7 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
             self?.hideLoading()
             switch result {
             case .success(let items): self?.update(content: items)
-            case .failure(let error): self?.show(error) { [weak self] in self?.goBackward() }
+            case .failure(let error): self?.handleError(error) { [weak self] in self?.goBackward() }
             }
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Foundation
 import MobileWorkflowCore
 
-class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewController, RemoteContentStepViewController {
+class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewController, RemoteContentStepViewController, ContentClearable {
     
     //MARK: Views
     private let stateView = StateView(frame: .zero)
@@ -25,8 +25,19 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
         self.view.addSubview(self.stateView)
         self.stateView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
         self.stateView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.resyncContent()
+    }
+
+    @objc func reloadContent() {
         self.loadContent()
+    }
+
+    func clearContent() {
+        self.update(content: MWStackStepContents(items: []))
     }
     
     // MARK: RemoteContentStepViewController

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -30,16 +30,6 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
     }
     
     // MARK: RemoteContentStepViewController
-    func loadContent() {
-        self.showLoading()
-        self.remoteContentStep.loadContent { [weak self] result in
-            self?.hideLoading()
-            switch result {
-            case .success(let items): self?.update(content: items)
-            case .failure(let error): self?.show(error) { [weak self] in self?.goBackward() }
-            }
-        }
-    }
     
     func update(content: MWStackStepContents) {
         self.remoteContentStep.contents = content

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -30,6 +30,16 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
     }
     
     // MARK: RemoteContentStepViewController
+    func loadContent() {
+        self.showLoading()
+        self.remoteContentStep.loadContent { [weak self] result in
+            self?.hideLoading()
+            switch result {
+            case .success(let items): self?.update(content: items)
+            case .failure(let error): self?.show(error) { [weak self] in self?.goBackward() }
+            }
+        }
+    }
     
     func update(content: MWStackStepContents) {
         self.remoteContentStep.contents = content


### PR DESCRIPTION
This change brings back the handling of unauthorized requests to MWNetworkContentDisplayStackViewController.

### Issue

The issue was discovered when exploring the following ticket

[MW-1706] Profile page is blank when user signs out from the first session & sign back in again.

### Implementation

**RemoteContentStepViewController** has a _handleError_ function which calls _handleAuthenticationError_ on 401. This trigger the authentication workflow. But **MWNetworkContentDisplayStackViewController** was overriding this handling. The same issue is present in **MWNetworkFormStepViewController**, I will raise a separate PR for that.





[MW-1706]: https://futureworkshops.atlassian.net/browse/MW-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ