### PR TITLE
Task/action sheet buttons

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.0.8'
+    s.version               = '1.1.0'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
@@ -84,7 +84,12 @@ public class MWContentDisplayStackViewController: MWStepViewController, Workflow
     }
     
     func handleButtonItemTapped(_ item: MWStackStepItemButton, in rect: CGRect) {
-        if let modalWorkflow = item.modalWorkflow {
+        
+        if let actionSheetButtons = item.actionSheetButtons {
+        
+            self.presentActionSheet(actionSheetButtons, from: item, rect: rect)
+        
+        } else if let modalWorkflow = item.modalWorkflow {
             self.workflowPresentationDelegate?.presentWorkflowWithName(modalWorkflow, isDiscardable: true, animated: true) { [weak self] reason in
                 if reason == .completed {
                     self?.handleSuccessAction(item.sucessAction)
@@ -102,6 +107,25 @@ public class MWContentDisplayStackViewController: MWStepViewController, Workflow
         else {
             self.handleSuccessAction(item.sucessAction)
         }
+    }
+    
+    private func presentActionSheet(_ buttons: [MWStackStepItemButton], from buttonItem: MWStackStepItemButton, rect: CGRect) {
+        
+        let controller = UIAlertController(title: buttonItem.label, message: nil, preferredStyle: .actionSheet)
+        
+        buttons.forEach { button in
+            let style : UIAlertAction.Style = button.style == .danger ? .destructive : .default
+            let buttonAction = UIAlertAction(title: button.label, style: style, handler: { [weak self] _ in
+                                                  self?.handleButtonItemTapped(button, in: rect)
+                                             })
+            controller.addAction(buttonAction)
+        }
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        controller.addAction(cancelAction)
+        
+        self.present(controller, animated: true, completion: nil)
+        
     }
     
     //MARK: SuccessActionHandler


### PR DESCRIPTION
[MW-2005]

I added a new boolean property to the button item called `showSubsequentButtonsGrouped` in the Styled Stack V2 plugin. When this is true, the following buttons in the list are added as sub buttons and displayed in an action sheet. If a different item type or a button with the property true is detected, then we stop adding buttons to the current one.

![Screenshot 2021-12-17 at 11 16 02](https://user-images.githubusercontent.com/1862078/146537472-5826ba87-b3c8-43f2-92f9-5c92d2343972.png)




[MW-2005]: https://futureworkshops.atlassian.net/browse/MW-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ