### PR TITLE
Task/header profile style

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.1.0'
+    s.version               = '1.2.0'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -10,19 +10,28 @@ import MobileWorkflowCore
 
 /// Describes the data model for the vertical stack. It includes the header + items data
 struct MWStackStepContents {
+    
+    enum HeaderStyle: String, Codable {
+        case fullWidth
+        case profile
+    }
+    
     let headerTitle: String?
     let headerImageURL: URL?
+    let headerStyle: HeaderStyle
     let items: [MWStackStepItem]
     
-    init(headerTitle: String? = nil, headerImageURL: URL? = nil, items: [MWStackStepItem]){
+    init(headerTitle: String? = nil, headerImageURL: URL? = nil, headerStyle: HeaderStyle = .fullWidth, items: [MWStackStepItem]){
         self.headerTitle = headerTitle
         self.headerImageURL = headerImageURL
+        self.headerStyle = headerStyle
         self.items = items
     }
     
     init(json: [String:Any], localizationService: LocalizationService) {
         self.headerTitle = localizationService.translate(json["title"] as? String)
         self.headerImageURL = (json["imageURL"] as? String).flatMap{ URL(string: $0) }
+        self.headerStyle = (json["headerStyle"] as? String).flatMap{ HeaderStyle(rawValue: $0) } ?? .fullWidth
         
         let jsonItems = (json["items"] as? Array<[String:Any]>) ?? []
         self.items = jsonItems.compactMap { MWStackStepItem(json: $0, localizationService: localizationService) }.resolvingActionSheetButtons()

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -27,26 +27,55 @@ struct MWStackView: View {
         // You'd think that setting the `headerHeight` to 0.0 and return nil on the header if there's no `headerImageURL` would
         // work, but it doesn't. If you don't use the correct init (the one that doesn't expect a header), the offset
         // of the ScrollView is completely broken.
-        if let headerImageURL = contents.headerImageURL {
-            return FancyScrollView(title: contents.headerTitle ?? "", headerHeight: 280, scrollUpHeaderBehavior: .parallax, scrollDownHeaderBehavior: .sticky, header: {
-                KFImage(headerImageURL)
-                    .placeholder {
-                        makeImagePlaceholder()
-                    }
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            }, content: {
-                self.makeContentScrollView()
-            }, isCloseButtonEnabled: isCloseButtonEnabled,
-            isBackButtonEnabled: isBackButtonEnabled,
-            backButtonTapped: self.backButtonTapped)
-        } else {
-            return FancyScrollView(content: {
-                self.makeContentScrollView()
-            }, isCloseButtonEnabled: isCloseButtonEnabled,
-            isBackButtonEnabled: isBackButtonEnabled,
-            backButtonTapped: self.backButtonTapped)
+        GeometryReader { geometry in
+            let headerHeight: CGFloat = 280.0
+            if let headerImageURL = contents.headerImageURL {
+                FancyScrollView(title: contents.headerTitle ?? "", headerHeight: headerHeight, scrollUpHeaderBehavior: .parallax, scrollDownHeaderBehavior: .sticky, header: {
+                    self.makeHeaderImageView(headerImageURL,
+                                             headerHeight: headerHeight,
+                                             safeAreaInsets: geometry.safeAreaInsets,
+                                             headerStyle: contents.headerStyle)
+                }, content: {
+                    self.makeContentScrollView()
+                }, isCloseButtonEnabled: isCloseButtonEnabled,
+                                isBackButtonEnabled: isBackButtonEnabled,
+                                backButtonTapped: self.backButtonTapped)
+            } else {
+                FancyScrollView(content: {
+                    self.makeContentScrollView()
+                }, isCloseButtonEnabled: isCloseButtonEnabled,
+                isBackButtonEnabled: isBackButtonEnabled,
+                backButtonTapped: self.backButtonTapped)
+            }
         }
+        
+    }
+    
+    @ViewBuilder
+    private func makeHeaderImageView(_ headerImageURL: URL,
+                                     headerHeight: CGFloat,
+                                     safeAreaInsets: EdgeInsets,
+                                     headerStyle: MWStackStepContents.HeaderStyle) -> some View {
+        
+        let kfImage = KFImage(headerImageURL)
+                        .placeholder {
+                            makeImagePlaceholder()
+                        }
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+        
+        switch headerStyle {
+        case .fullWidth:
+            kfImage
+        case .profile:
+            let edgeInsets = EdgeInsets(top: safeAreaInsets.top, leading: 0, bottom: 70.0, trailing: 0)
+            let imageSize = headerHeight - edgeInsets.top - edgeInsets.bottom
+            kfImage
+                .frame(width: imageSize, height: imageSize, alignment: .center)
+                .cornerRadius(.infinity)
+                .padding(edgeInsets)
+        }
+        
     }
     
     private func makeImagePlaceholder() -> some View {


### PR DESCRIPTION
[MW-2008]

This is just one part of the ticket, where we add the profile style to the styled stack content header view so that it displays like the following. I tried to do it with the least changes to existing code.

![Simulator Screen Shot - iPhone 13 - 2021-12-21 at 13 11 24](https://user-images.githubusercontent.com/1862078/146936011-3caf03c7-8cf2-43d1-b962-f8cdf35c8f0c.png)

![Simulator Screen Shot - iPhone 13 - 2021-12-21 at 13 12 08](https://user-images.githubusercontent.com/1862078/146936014-678171ca-c6c1-403f-97f1-e3a871092aed.png)




[MW-2008]: https://futureworkshops.atlassian.net/browse/MW-2008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ