### PR TITLE
Bug/action sheet button

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.2.0'
+    s.version               = '1.2.1'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Models/MWStackStepContents.swift
@@ -66,6 +66,8 @@ extension Sequence where Iterator.Element == MWStackStepItem {
             
         }
         
+        update(presentingButton: nil)
+        
         return items
     }
     


### PR DESCRIPTION
[MW-2005] 

fix a bug where the root button is not added if the list ends on an action sheet button. 

After looping through the list of items, add the button if it exists.

[MW-2005]: https://futureworkshops.atlassian.net/browse/MW-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ