### PR TITLE
fixed header image not rounded for profile style

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.2.1'
+    s.version               = '1.2.2'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -72,7 +72,7 @@ struct MWStackView: View {
             let imageSize = headerHeight - edgeInsets.top - edgeInsets.bottom
             kfImage
                 .frame(width: imageSize, height: imageSize, alignment: .center)
-                .cornerRadius(.infinity)
+                .cornerRadius(imageSize/2)
                 .padding(edgeInsets)
         }
         


### PR DESCRIPTION
[MW-2007]

Fixed a Swift UI bug where infinite corner radius does not work for iOS 13 and 14. So using half image size instead.

[MW-2007]: https://futureworkshops.atlassian.net/browse/MW-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ