### PR TITLE
[WELBA-143] Added the correct behavior to the close button for welba

### DIFF
--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
@@ -72,7 +72,12 @@ public class MWContentDisplayStackViewController: MWStepViewController, Workflow
     }
     
     func handleBackButtonTapped() {
-        if let navController = self.navigationController, navController.viewControllers.count > 1 {
+        if !isBackButtonEnabled {
+            // This is just for WELBA, the correct implementation should allow the app-builder to
+            // define what the close button does in each flow (currently unsupported). For the welba use-case, tapping close
+            // means moving forward because this UIViewController is shown as the last one in a modal flow (and therefore gets dismissed)
+            self.goForward()
+        } else if let navController = self.navigationController, navController.viewControllers.count > 1 {
             self.goBackward()
         } else {
             if let target = self.cancelButtonItem?.target, let action = self.cancelButtonItem?.action {


### PR DESCRIPTION
Stacks that don't display the back button must be completely dismissed when tapped the X. This fix is mainly for WELBA, not sure if in normal apps will break things, but since we're working on a WELBA branch only, this change is fine.

Ideally, the App Builder should tell the app what needs to happen once the X is tapped so regular workflows and modal workflows can have the correct behavior, but that's not yet supported.

Tested the change with Montse on all the screens that we could think of and now works as expected.

https://user-images.githubusercontent.com/8229382/153618830-6b95e628-5924-401b-b43f-f26ac3d2ea00.MP4


