### PR TITLE
Fixed large section header margin

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.5.0'
+    s.version               = '1.5.1'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -121,9 +121,9 @@ class MWGridStepViewController: MWStepViewController {
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(44))
         let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: MWSimpleCollectionSectionHeader.defaultReuseIdentifier, alignment: .top)
         sectionHeader.contentInsets = NSDirectionalEdgeInsets(top: 0,
-                                                              leading: orthogonalScrollingBehavior == .groupPagingCentered ? 8 : 0,
+                                                              leading: orthogonalScrollingBehavior == .groupPagingCentered ? 16 : 0,
                                                               bottom: 0,
-                                                              trailing: orthogonalScrollingBehavior == .groupPagingCentered ? 8 : 0)
+                                                              trailing: orthogonalScrollingBehavior == .groupPagingCentered ? 16 : 0)
         
         // Section
         let section = NSCollectionLayoutSection(group: group)


### PR DESCRIPTION
### Task

[[iOS] Styled Content / Grid titles alignment off](https://3.basecamp.com/5245563/buckets/26145695/todos/4829259777/edit?replace=true)

### Summary

The large section header margin does not align with other content.

### Implementation

Updated the header contentInsets for large sections to ensure consistent margins.