### PR TITLE
Animated transition for remotely loaded images

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.5.1'
+    s.version               = '1.5.2'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
@@ -113,9 +113,9 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         if let imageUrl = viewData.imageUrl {
             self.imageView.image = self.placeholderImage
             self.imageView.backgroundColor = theme.imagePlaceholderBackgroundColor
-            self.imageLoadTask = imageLoader.fromCacheElseAsyncLoad(image: imageUrl.absoluteString, session: session) { [weak self] image, fromCache in
+            self.imageLoadTask = imageLoader.load(image: imageUrl.absoluteString, session: session) { [weak self] result in
                 guard let strongSelf = self else { return }
-                strongSelf.imageView.transition(to: image ?? strongSelf.placeholderImage, animated: !fromCache)
+                strongSelf.imageView.transition(to: result.image ?? strongSelf.placeholderImage, animated: result.wasLoadedRemotely)
             }
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
@@ -115,7 +115,7 @@ class MWImageCollectionViewCell: UICollectionViewCell {
             self.imageView.backgroundColor = theme.imagePlaceholderBackgroundColor
             self.imageLoadTask = imageLoader.asyncLoad(image: imageUrl.absoluteString, session: session) { [weak self] (image) in
                 guard let strongSelf = self else { return }
-                strongSelf.imageView.image = image ?? strongSelf.placeholderImage
+                strongSelf.imageView.transition(to: image ?? strongSelf.placeholderImage, animated: true)
             }
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
@@ -113,9 +113,9 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         if let imageUrl = viewData.imageUrl {
             self.imageView.image = self.placeholderImage
             self.imageView.backgroundColor = theme.imagePlaceholderBackgroundColor
-            self.imageLoadTask = imageLoader.asyncLoad(image: imageUrl.absoluteString, session: session) { [weak self] (image) in
+            self.imageLoadTask = imageLoader.fromCacheElseAsyncLoad(image: imageUrl.absoluteString, session: session) { [weak self] image, fromCache in
                 guard let strongSelf = self else { return }
-                strongSelf.imageView.transition(to: image ?? strongSelf.placeholderImage, animated: true)
+                strongSelf.imageView.transition(to: image ?? strongSelf.placeholderImage, animated: !fromCache)
             }
         }
     }


### PR DESCRIPTION
### Task

[[iOS] [Android] Image loading states](https://3.basecamp.com/5245563/buckets/26145695/todos/4825281143/edit?replace=true)

### Summary

Adding animated transition to loaded image.

### Implementation

Updated to use `ImageLoadingService` `load(image:session:completion:)` and `UIImageView` `transition(to:animated:completion:)` to update the image. 
