### PR TITLE
[iOS] [Android?] Stack url buttons should support PATCH

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.5.3'
+    s.version               = '1.5.4'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -90,11 +90,11 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
     private func performButtonRemoteRequest(to url: URL, usingHTTPMethod httpMethod: HTTPMethod, successAction: SuccessAction) {
         guard let url = self.remoteContentStep.session.resolve(url: url.absoluteString) else { return }
         // Only PUT/DELETE are supported on buttons
-        guard httpMethod == .PUT || httpMethod == .DELETE else { return }
+        guard [.PUT, .PATCH, .DELETE].contains(httpMethod) else { return }
         do {
             let credential = try self.remoteContentStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get()
             let task = URLAsyncTask<MWStackStepContents?>.build(url: url, method: httpMethod, session: self.remoteContentStep.session, credential: credential, headers: [:]) { data -> MWStackStepContents? in
-                if httpMethod == .PUT {
+                if [.PUT, .PATCH].contains(httpMethod) {
                     guard let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String:Any] else {
                         throw ParseError.invalidServerData(cause: "Unexpected JSON format.")
                     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -89,7 +89,7 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
     
     private func performButtonRemoteRequest(to url: URL, usingHTTPMethod httpMethod: HTTPMethod, successAction: SuccessAction) {
         guard let url = self.remoteContentStep.session.resolve(url: url.absoluteString) else { return }
-        // Only PUT/DELETE are supported on buttons
+        // Only these methods currently supported for buttons
         guard [.PUT, .PATCH, .DELETE].contains(httpMethod) else { return }
         do {
             let credential = try self.remoteContentStep.services.credentialStore.retrieveCredential(.token, isRequired: false).get()


### PR DESCRIPTION
### Task

[[iOS] [Android?] Stack url buttons should support PATCH](https://3.basecamp.com/5245563/buckets/26145695/todos/4937814394/edit?replace=true)

### Feature/Issue

We currently limit stack button url actions to PUT and DELETE, and we should add support for PATCH.

### Implementation

Opting into supporting PATCH using the same flow logic as PUT.