### PR TITLE
[iOS] Remove SF Symbols icon from image placeholder

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.6.0'
+    s.version               = '1.6.1'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
@@ -23,37 +23,6 @@ class MWImageCollectionViewCell: UICollectionViewCell {
     @MainActor private let imageView = UIImageView()
     private var imageLoadTask: Task<(), Never>?
     
-    private lazy var placeholderImage: UIImage? = {
-        let size = CGSize(width: 500, height: 500/2)
-        
-        UIGraphicsBeginImageContext(size)
-        guard let context = UIGraphicsGetCurrentContext() else {
-            return nil
-        }
-        context.translateBy(x: 0, y: size.height)
-        context.scaleBy(x: 1.0, y: -1.0);
-        context.setBlendMode(.normal)
-        
-        let imageConfig = UIImage.SymbolConfiguration(textStyle: .largeTitle)
-        guard let image = UIImage(systemName: "photo", withConfiguration: imageConfig) else {
-            return nil
-        }
-        
-        // Center image
-        let x = (size.width / 2) - (image.size.width / 2)
-        let y = (size.height / 2) - (image.size.height / 2)
-        
-        let rect = CGRect(x: x, y: y, width: image.size.width, height: image.size.height)
-        context.clip(to: rect, mask: image.cgImage!)
-        UIColor.systemGray2.setFill()
-        context.fill(rect)
-        
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return newImage
-    }()
-    
     //MARK: Lifecycle
     override init(frame: CGRect) {
         
@@ -110,11 +79,11 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         self.imageView.layer.cornerRadius = isLargeSection ? 16.0 : 12.0
         self.imageLoadTask?.cancel()
         if let imageUrl = viewData.imageUrl {
-            self.imageView.image = self.placeholderImage
+            self.imageView.image = nil
             self.imageView.backgroundColor = theme.imagePlaceholderBackgroundColor
             self.imageLoadTask = Task {
                 let result = await imageLoader.load(image: imageUrl.absoluteString, session: session)
-                self.imageView.transition(to: result.image ?? self.placeholderImage, animated: result.wasLoadedRemotely)
+                self.imageView.transition(to: result.image, animated: result.wasLoadedRemotely)
             }
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/SwiftUIViews/MWStackView.swift
@@ -58,9 +58,6 @@ struct MWStackView: View {
                                      headerStyle: MWStackStepContents.HeaderStyle) -> some View {
         
         let kfImage = KFImage(headerImageURL)
-                        .placeholder {
-                            makeImagePlaceholder()
-                        }
                         .resizable()
                         .aspectRatio(contentMode: .fill)
         
@@ -77,15 +74,6 @@ struct MWStackView: View {
         }
         
     }
-    
-    private func makeImagePlaceholder() -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.systemFill(.secondary))
-            Image(systemName: "photo")
-                .foregroundColor(Color.label(.tertiary))
-                .font(.largeTitle)
-        }    }
     
     private func makeContentScrollView() -> some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -132,9 +120,6 @@ fileprivate struct MWListItemView: View {
         HStack {
             if let imageURL = stepTypeListItem.imageURL {
                 KFImage(imageURL)
-                    .placeholder {
-                        makeImagePlaceholder()
-                    }
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(width: 48, height: 48, alignment: .center)
@@ -151,16 +136,6 @@ fileprivate struct MWListItemView: View {
                         .foregroundColor(Color(UIColor.secondaryLabel))
                 }
             }
-        }
-    }
-    
-    func makeImagePlaceholder() -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.systemFill(.secondary))
-                .frame(width: 48, height: 48, alignment: .center)
-            Image(systemName: "photo")
-                .foregroundColor(Color.label(.tertiary))
         }
     }
 }


### PR DESCRIPTION
### Task

[[iOS] Remove SF Symbols icon from image placeholder](https://3.basecamp.com/5245563/buckets/26145695/todos/5911910967/edit?replace=true)

### Feature/Issue

Remove the SFSymbol 'photo' icon from the grid cell imageView placeholder.

### Implementation

Updated the UI in to show just the placeholder background colour without the icon.