### PR TITLE
[iOS] UI glitch when returning to list step and reloading images

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.6.1'
+    s.version               = '1.6.2'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -30,6 +30,8 @@ class MWGridStepViewController: MWStepViewController {
     
     var gridStep: GridStep { self.mwStep as! GridStep }
     
+    private lazy var remoteImageCache: RemoteImageCache = { RemoteImageCache() }()
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = self.step.theme.primaryBackgroundColor
@@ -159,12 +161,12 @@ extension MWGridStepViewController: UICollectionViewDataSource, UICollectionView
         switch section.type {
         case .carouselLarge:
             let cell: MWImageCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
-            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: true, imageLoader: self.gridStep.services.imageLoadingService, session: self.gridStep.session, theme: self.step.theme)
+            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: true, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme)
             result = cell
             
         case .carouselSmall:
             let cell: MWImageCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
-            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: false, imageLoader: self.gridStep.services.imageLoadingService, session: self.gridStep.session, theme: self.step.theme)
+            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: false, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme)
             result = cell
             
         case .item: preconditionFailure("Not a section")

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Local/MWContentDisplayStackViewController.swift
@@ -108,9 +108,9 @@ public class MWContentDisplayStackViewController: MWStepViewController, Presenta
             let triggerShareSheet: (([Any]) -> Void) = { [weak self] itemsToShare in
                 self?.hideLoadingIndicator()
                 // Present the share sheet when everything is ready
-                guard let self = self, !itemsToShare.isEmpty else { return }
+                guard let strongSelf = self, !itemsToShare.isEmpty else { return }
                 UIPasteboard.general.string = itemsToShare.compactMap{ $0 as? String }.joined(separator: " ")
-                self.presentActivitySheet(with: itemsToShare, sourceRect: rect)
+                strongSelf.presentActivitySheet(with: itemsToShare, sourceRect: rect)
             }
             
             // Collect all the shareable items
@@ -129,14 +129,14 @@ public class MWContentDisplayStackViewController: MWStepViewController, Presenta
             
             if let imageURL = item.shareImageURL {
                 self.contentStackStep.downloadShareableImage(from: imageURL) { [weak self] result in
-                    guard let self = self else { return }
+                    guard let strongSelf = self else { return }
                     DispatchQueue.main.async {
                         switch result {
                         case .success(let image):
                             // Always add it as the first element
                             itemsToShare.insert(image, at: 0)
                         case .failure(let error):
-                            self.show(error)
+                            strongSelf.show(error)
                         }
                         triggerShareSheet(itemsToShare)
                     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentStackStep/Remote/MWNetworkContentDisplayStackViewController.swift
@@ -105,15 +105,15 @@ class MWNetworkContentDisplayStackViewController: MWContentDisplayStackViewContr
                 }
             }
             self.remoteContentStep.services.perform(task: task, session: self.remoteContentStep.session) { [weak self] result in
-                guard let self = self else { return }
+                guard let strongSelf = self else { return }
                 switch result {
                 case .success(let newContents):
                     if let newContents = newContents {
-                        self.update(content: newContents)
+                        strongSelf.update(content: newContents)
                     }
-                    self.handleSuccessAction(successAction)
+                    strongSelf.handleSuccessAction(successAction)
                 case .failure(let error):
-                    self.show(error)
+                    strongSelf.show(error)
                 }
             }
         } catch (let error) {


### PR DESCRIPTION
### Task

[[iOS] UI glitch when returning to list step and reloading images](https://3.basecamp.com/5245563/buckets/26145695/todos/5926307088/edit?replace=true)

### Feature/Issue

Prevent UI 'glitch' when reusing collection view cells containing remotely loaded images.

### Implementation

Using `RemoteImageCache` in grid steps.