### PR TITLE
[iOS] [Android] [Rails] Allow users to favourite content

### DIFF
--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.7.1'
+    s.version               = '1.8.0'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin.podspec
+++ b/MWContentDisplayPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWContentDisplayPlugin'
-    s.version               = '1.7.0'
+    s.version               = '1.7.1'
     s.summary               = 'A content display plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Grid step for MobileWorkflow on iOS, using UICollectionView compositional layout.

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStep.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStep.swift
@@ -50,7 +50,7 @@ extension MWGridStep: BuildableStep {
             guard let id = $0.getString(key: "listItemId") ?? $0.getString(key: "id") else {
                 throw ParseError.invalidStepData(cause: "Grid item has invalid id")
             }
-            return GridStepItem(id: id, type: $0["type"] as? String, text: text, detailText: detailText, imageURL: $0["imageURL"] as? String)
+            return GridStepItem(id: id, type: $0["type"] as? String, text: text, detailText: detailText, imageURL: $0["imageURL"] as? String, favorite: $0["favorite"] as? Bool, favoriteURL: $0["favoriteURL"] as? String)
         }
         return MWGridStep(identifier: stepInfo.data.identifier, session: stepInfo.session, services: services, theme: stepInfo.context.theme, items: items)
     }
@@ -83,7 +83,7 @@ extension GridStep {
             vcSections.append(self.viewControllerSectionFromSection(currentSection, items: currentItems))
         } else if !currentItems.isEmpty {
             // no sections found, add all to single section
-            let section = GridStepItem(id: "DEFAULT_SECTION", type: GridItemType.carouselSmall.rawValue, text: nil, detailText: nil, imageURL: nil)
+            let section = GridStepItem(id: "DEFAULT_SECTION", type: GridItemType.carouselSmall.rawValue, text: nil, detailText: nil, imageURL: nil, favorite: nil, favoriteURL: nil)
             vcSections.append(self.viewControllerSectionFromSection(section, items: currentItems))
         }
         
@@ -92,7 +92,7 @@ extension GridStep {
     
     private func viewControllerSectionFromSection(_ section: GridStepItem, items: [GridStepItem]) -> MWGridStepViewController.Section {
         
-        let vcItems = items.map { MWGridStepViewController.Item(id: $0.id, title: $0.text, subtitle: $0.detailText, imageUrl: $0.imageURL.flatMap { URL(string: $0) }) }
+        let vcItems = items.map { MWGridStepViewController.Item(id: $0.id, title: $0.text, subtitle: $0.detailText, imageUrl: $0.imageURL.flatMap { URL(string: $0) }, favorite: $0.favorite, favoriteURL: $0.favoriteURL) }
         
         let vcSection = MWGridStepViewController.Section(id: section.id, type: section.itemType, title: section.text, items: vcItems)
         
@@ -107,15 +107,19 @@ public struct GridGridItem: Codable {
     let imageURL: String?
     let text: String?
     let type: String?
+    let favorite: Bool?
+    let favoriteURL: String?
     
     public static func gridGridItem(
         listItemId: Float,
         detailText: String? = nil,
+        favorite: Bool? = nil,
+        favoriteURL: String? = nil,
         imageURL: String? = nil,
         text: String? = nil,
         type: String? = nil
     ) -> GridGridItem {
-        GridGridItem(listItemId: listItemId, detailText: detailText, imageURL: imageURL, text: text, type: type)
+        GridGridItem(listItemId: listItemId, detailText: detailText, imageURL: imageURL, text: text, type: type, favorite: favorite, favoriteURL: favoriteURL)
     }
 }
 

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStep.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStep.swift
@@ -50,7 +50,22 @@ extension MWGridStep: BuildableStep {
             guard let id = $0.getString(key: "listItemId") ?? $0.getString(key: "id") else {
                 throw ParseError.invalidStepData(cause: "Grid item has invalid id")
             }
-            return GridStepItem(id: id, type: $0["type"] as? String, text: text, detailText: detailText, imageURL: $0["imageURL"] as? String, favorite: $0["favorite"] as? Bool, favoriteURL: $0["favoriteURL"] as? String)
+            let actionMethod: HTTPMethod?
+            if let stored = $0["actionMethod"] as? String {
+                actionMethod = HTTPMethod(rawValue: stored)
+            } else {
+                actionMethod = nil
+            }
+            return GridStepItem(
+                id: id,
+                type: $0["type"] as? String,
+                text: text,
+                detailText: detailText,
+                imageURL: $0["imageURL"] as? String,
+                actionURL: $0["actionURL"] as? String,
+                actionSFSymbolName: $0["actionSFSymbolName"] as? String,
+                actionMethod: actionMethod
+            )
         }
         return MWGridStep(identifier: stepInfo.data.identifier, session: stepInfo.session, services: services, theme: stepInfo.context.theme, items: items)
     }
@@ -83,7 +98,7 @@ extension GridStep {
             vcSections.append(self.viewControllerSectionFromSection(currentSection, items: currentItems))
         } else if !currentItems.isEmpty {
             // no sections found, add all to single section
-            let section = GridStepItem(id: "DEFAULT_SECTION", type: GridItemType.carouselSmall.rawValue, text: nil, detailText: nil, imageURL: nil, favorite: nil, favoriteURL: nil)
+            let section = GridStepItem(id: "DEFAULT_SECTION", type: GridItemType.carouselSmall.rawValue, text: nil, detailText: nil, imageURL: nil, actionURL: nil, actionSFSymbolName: nil, actionMethod: nil)
             vcSections.append(self.viewControllerSectionFromSection(section, items: currentItems))
         }
         
@@ -92,7 +107,7 @@ extension GridStep {
     
     private func viewControllerSectionFromSection(_ section: GridStepItem, items: [GridStepItem]) -> MWGridStepViewController.Section {
         
-        let vcItems = items.map { MWGridStepViewController.Item(id: $0.id, title: $0.text, subtitle: $0.detailText, imageUrl: $0.imageURL.flatMap { URL(string: $0) }, favorite: $0.favorite, favoriteURL: $0.favoriteURL) }
+        let vcItems = items.map { MWGridStepViewController.Item(id: $0.id, title: $0.text, subtitle: $0.detailText, imageUrl: $0.imageURL.flatMap { URL(string: $0) }, actionURL: $0.actionURL, actionMethod: $0.actionMethod, actionSymbol: $0.actionSFSymbolName) }
         
         let vcSection = MWGridStepViewController.Section(id: section.id, type: section.itemType, title: section.text, items: vcItems)
         

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -58,7 +58,7 @@ class MWGridStepViewController: MWStepViewController {
         self.collectionView.reloadData()
     }
     
-    open func favorite(item: GridStepItem) {
+    open func toggleFavorite(item: Item) async {
         //Favorite toggle is not done for static items
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -16,6 +16,10 @@ class MWGridStepViewController: MWStepViewController {
         let title: String?
         let subtitle: String?
         let imageUrl: URL?
+        let favorite: Bool?
+        let favoriteURL: String?
+        
+        var hasFavoriteSupport: Bool { self.favorite != nil && !(self.favoriteURL?.isEmpty ?? true) }
     }
     
     struct Section {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -58,8 +58,9 @@ class MWGridStepViewController: MWStepViewController {
         self.collectionView.reloadData()
     }
     
-    open func toggleFavorite(item: Item) async {
+    open func toggleFavorite(item: Item) async -> Bool {
         //Favorite toggle is not done for static items
+        false
     }
     
     // MARK: Configuration
@@ -169,12 +170,16 @@ extension MWGridStepViewController: UICollectionViewDataSource, UICollectionView
         switch section.type {
         case .carouselLarge:
             let cell: MWImageCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
-            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: true, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme)
+            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: true, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme) { [weak self] in
+                return await self?.toggleFavorite(item: item) ?? false
+            }
             result = cell
             
         case .carouselSmall:
             let cell: MWImageCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
-            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: false, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme)
+            cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: false, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme) { [weak self] in
+                return await self?.toggleFavorite(item: item) ?? false
+            }
             result = cell
             
         case .item: preconditionFailure("Not a section")
@@ -215,6 +220,6 @@ extension MWGridStepViewController: UICollectionViewDataSource, UICollectionView
 private extension MWImageCollectionViewCell.ViewData {
     
     init(item: MWGridStepViewController.Item) {
-        self.init(title: item.title, subtitle: item.subtitle, imageUrl: item.imageUrl)
+        self.init(title: item.title, subtitle: item.subtitle, imageUrl: item.imageUrl, showFavorite: item.hasFavoriteSupport, isFavorite: item.favorite ?? false)
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -58,6 +58,10 @@ class MWGridStepViewController: MWStepViewController {
         self.collectionView.reloadData()
     }
     
+    open func favorite(item: GridStepItem) {
+        //Favorite toggle is not done for static items
+    }
+    
     // MARK: Configuration
     
     private func setupCollectionView() {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Local/MWGridStepViewController.swift
@@ -16,10 +16,15 @@ class MWGridStepViewController: MWStepViewController {
         let title: String?
         let subtitle: String?
         let imageUrl: URL?
-        let favorite: Bool?
-        let favoriteURL: String?
+        let actionURL: String?
+        let actionMethod: HTTPMethod?
+        let actionSymbol: String?
         
-        var hasFavoriteSupport: Bool { self.favorite != nil && !(self.favoriteURL?.isEmpty ?? true) }
+        var canPerformRemoteAction: Bool {
+            !(self.actionSymbol?.isEmpty ?? true)
+            && !(self.actionURL?.isEmpty ?? true)
+            && self.actionMethod != nil
+        }
     }
     
     struct Section {
@@ -58,9 +63,8 @@ class MWGridStepViewController: MWStepViewController {
         self.collectionView.reloadData()
     }
     
-    open func toggleFavorite(item: Item) async -> Bool {
+    open func performRemoteAction(item: Item) async -> Void {
         //Favorite toggle is not done for static items
-        false
     }
     
     // MARK: Configuration
@@ -171,14 +175,14 @@ extension MWGridStepViewController: UICollectionViewDataSource, UICollectionView
         case .carouselLarge:
             let cell: MWImageCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
             cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: true, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme) { [weak self] in
-                return await self?.toggleFavorite(item: item) ?? false
+                await self?.performRemoteAction(item: item)
             }
             result = cell
             
         case .carouselSmall:
             let cell: MWImageCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
             cell.configure(viewData: MWImageCollectionViewCell.ViewData(item: item), isLargeSection: false, imageLoader: self.gridStep.services.imageLoadingService, imageCache: self.remoteImageCache, session: self.gridStep.session, theme: self.step.theme) { [weak self] in
-                return await self?.toggleFavorite(item: item) ?? false
+                await self?.performRemoteAction(item: item)
             }
             result = cell
             
@@ -220,6 +224,6 @@ extension MWGridStepViewController: UICollectionViewDataSource, UICollectionView
 private extension MWImageCollectionViewCell.ViewData {
     
     init(item: MWGridStepViewController.Item) {
-        self.init(title: item.title, subtitle: item.subtitle, imageUrl: item.imageUrl, showFavorite: item.hasFavoriteSupport, isFavorite: item.favorite ?? false)
+        self.init(title: item.title, subtitle: item.subtitle, imageUrl: item.imageUrl, showAction: item.canPerformRemoteAction, actionSymbol: item.actionSymbol ?? "")
     }
 }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Models/GridStepItem.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Models/GridStepItem.swift
@@ -30,6 +30,8 @@ public class GridStepItem: Codable {
     public let text: String?
     public let detailText: String?
     public let imageURL: String?
+    public let favorite: Bool?
+    public let favoriteURL: String?
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -38,14 +40,18 @@ public class GridStepItem: Codable {
         self.type = try container.decodeIfPresent(String.self, forKey: .type)
         self.detailText = try container.decodeIfPresent(String.self, forKey: .detailText)
         self.imageURL = try container.decodeIfPresent(String.self, forKey: .imageURL)
+        self.favorite = try container.decodeIfPresent(Bool.self, forKey: .favorite)
+        self.favoriteURL = try container.decodeIfPresent(String.self, forKey: .favoriteURL)
     }
     
-    public init(id: String, type: String?, text: String?, detailText: String?, imageURL: String?) {
+    public init(id: String, type: String?, text: String?, detailText: String?, imageURL: String?, favorite: Bool?, favoriteURL: String?) {
         self.id = id
         self.type = type
         self.text = text
         self.detailText = detailText
         self.imageURL = imageURL
+        self.favorite = favorite
+        self.favoriteURL = favoriteURL
     }
 }
 

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Models/GridStepItem.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Models/GridStepItem.swift
@@ -53,6 +53,10 @@ public class GridStepItem: Codable {
         self.favorite = favorite
         self.favoriteURL = favoriteURL
     }
+    
+    public func updating(favorite: Bool?) -> GridStepItem {
+        GridStepItem(id: id, type: type, text: text, detailText: detailText, imageURL: imageURL, favorite: favorite, favoriteURL: favoriteURL)
+    }
 }
 
 extension GridStepItem {

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Models/GridStepItem.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Models/GridStepItem.swift
@@ -30,8 +30,9 @@ public class GridStepItem: Codable {
     public let text: String?
     public let detailText: String?
     public let imageURL: String?
-    public let favorite: Bool?
-    public let favoriteURL: String?
+    public let actionURL: String?
+    public let actionSFSymbolName: String?
+    public let actionMethod: HTTPMethod?
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -40,22 +41,24 @@ public class GridStepItem: Codable {
         self.type = try container.decodeIfPresent(String.self, forKey: .type)
         self.detailText = try container.decodeIfPresent(String.self, forKey: .detailText)
         self.imageURL = try container.decodeIfPresent(String.self, forKey: .imageURL)
-        self.favorite = try container.decodeIfPresent(Bool.self, forKey: .favorite)
-        self.favoriteURL = try container.decodeIfPresent(String.self, forKey: .favoriteURL)
+        self.actionURL = try container.decodeIfPresent(String.self, forKey: .actionURL)
+        self.actionSFSymbolName = try container.decodeIfPresent(String.self, forKey: .actionSFSymbolName)
+        if let stored = try container.decodeIfPresent(String.self, forKey: .actionMethod) {
+            self.actionMethod = HTTPMethod(rawValue: stored)
+        } else {
+            self.actionMethod = nil
+        }
     }
     
-    public init(id: String, type: String?, text: String?, detailText: String?, imageURL: String?, favorite: Bool?, favoriteURL: String?) {
+    public init(id: String, type: String?, text: String?, detailText: String?, imageURL: String?, actionURL: String?, actionSFSymbolName: String?, actionMethod: HTTPMethod?) {
         self.id = id
         self.type = type
         self.text = text
         self.detailText = detailText
         self.imageURL = imageURL
-        self.favorite = favorite
-        self.favoriteURL = favoriteURL
-    }
-    
-    public func updating(favorite: Bool?) -> GridStepItem {
-        GridStepItem(id: id, type: type, text: text, detailText: detailText, imageURL: imageURL, favorite: favorite, favoriteURL: favoriteURL)
+        self.actionURL = actionURL
+        self.actionSFSymbolName = actionSFSymbolName
+        self.actionMethod = actionMethod
     }
 }
 

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
@@ -46,6 +46,8 @@ class MWNetworkGridStepViewController: MWGridStepViewController, RemoteContentSt
             return
         }
         
+        let currentState = self.remoteContentStep.items
+        
         do {
             let task: URLAsyncTask<Void> = URLAsyncTask<Void>.build(
                 url: resolvedURL,
@@ -56,6 +58,7 @@ class MWNetworkGridStepViewController: MWGridStepViewController, RemoteContentSt
             try await self.gridStep.services.perform(task: task, session: self.gridStep.session)
             self.loadContent()
         } catch {
+            self.update(content: currentState)
             await self.show(error)
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
@@ -39,23 +39,23 @@ class MWNetworkGridStepViewController: MWGridStepViewController, RemoteContentSt
         self.update(content: [])
     }
     
-    override func favorite(item: GridStepItem) {
+    override func toggleFavorite(item: Item) async {
         guard let favorite = item.favorite,
               let favoriteURL = item.favoriteURL,
               let resolvedURL = self.gridStep.session.resolve(url: favoriteURL) else {
             return
         }
-        Task { await self.toggle(favorite: favorite, url: resolvedURL) }
-    }
-    
-    private func toggle(favorite: Bool, url: URL) async {
-        self.showLoading()
+        
         do {
-            let task: URLAsyncTask<Data> = URLAsyncTask<Data>.build(url: url, method: favorite ? .PUT : .DELETE, session: self.gridStep.session)
-            let _ = try await self.gridStep.services.perform(task: task, session: self.gridStep.session)
+            let task: URLAsyncTask<Void> = URLAsyncTask<Void>.build(
+                url: resolvedURL,
+                method: favorite ? .DELETE : .PUT,
+                session: self.gridStep.session,
+                parser: { _ in () }
+            )
+            try await self.gridStep.services.perform(task: task, session: self.gridStep.session)
             self.loadContent()
         } catch {
-            self.hideLoading()
             await self.show(error)
         }
     }

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
@@ -39,11 +39,11 @@ class MWNetworkGridStepViewController: MWGridStepViewController, RemoteContentSt
         self.update(content: [])
     }
     
-    override func toggleFavorite(item: Item) async {
+    override func toggleFavorite(item: Item) async -> Bool {
         guard let favorite = item.favorite,
               let favoriteURL = item.favoriteURL,
               let resolvedURL = self.gridStep.session.resolve(url: favoriteURL) else {
-            return
+            return false
         }
         
         do {
@@ -55,8 +55,10 @@ class MWNetworkGridStepViewController: MWGridStepViewController, RemoteContentSt
             )
             try await self.gridStep.services.perform(task: task, session: self.gridStep.session)
             self.loadContent()
+            return true
         } catch {
             await self.show(error)
+            return false
         }
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Network/MWNetworkGridStepViewController.swift
@@ -39,26 +39,24 @@ class MWNetworkGridStepViewController: MWGridStepViewController, RemoteContentSt
         self.update(content: [])
     }
     
-    override func toggleFavorite(item: Item) async -> Bool {
-        guard let favorite = item.favorite,
-              let favoriteURL = item.favoriteURL,
-              let resolvedURL = self.gridStep.session.resolve(url: favoriteURL) else {
-            return false
+    override func performRemoteAction(item: MWGridStepViewController.Item) async -> Void {
+        guard let actionURL = item.actionURL,
+              let actionMethod = item.actionMethod,
+              let resolvedURL = self.gridStep.session.resolve(url: actionURL) else {
+            return
         }
         
         do {
             let task: URLAsyncTask<Void> = URLAsyncTask<Void>.build(
                 url: resolvedURL,
-                method: favorite ? .DELETE : .PUT,
+                method: actionMethod,
                 session: self.gridStep.session,
                 parser: { _ in () }
             )
             try await self.gridStep.services.perform(task: task, session: self.gridStep.session)
             self.loadContent()
-            return true
         } catch {
             await self.show(error)
-            return false
         }
     }
     

--- a/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
+++ b/MWContentDisplayPlugin/MWContentDisplayPlugin/ContentGridStep/Views/MWImageCollectionViewCell.swift
@@ -15,6 +15,8 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         let title: String?
         let subtitle: String?
         let imageUrl: URL?
+        let showFavorite: Bool
+        let isFavorite: Bool
     }
     
     //MARK: Class properties
@@ -22,6 +24,15 @@ class MWImageCollectionViewCell: UICollectionViewCell {
     private let subtitleLabel = UILabel()
     @MainActor private let imageView = UIImageView()
     private var imageLoadTask: Task<(), Never>?
+    private let favoriteButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.backgroundColor = .lightGray
+        button.layer.cornerRadius = 16.0
+        button.layer.masksToBounds = true
+        return button
+    }()
+    private var favoriteAction: () async -> Bool = { false }
     
     //MARK: Lifecycle
     override init(frame: CGRect) {
@@ -38,11 +49,23 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         self.subtitleLabel.font = .preferredFont(forTextStyle: .subheadline)
         self.subtitleLabel.textColor = .secondaryLabel
         
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.heightAnchor.constraint(equalTo: containerView.widthAnchor, multiplier: 9/16).isActive = true
+        
         self.imageView.translatesAutoresizingMaskIntoConstraints = false
         self.imageView.contentMode = .scaleAspectFill
         self.imageView.layer.cornerRadius = 16.0
         self.imageView.layer.masksToBounds = true
-        self.imageView.heightAnchor.constraint(equalTo: self.imageView.widthAnchor, multiplier: 9/16).isActive = true
+        
+        containerView.addPinnedSubview(self.imageView)
+        containerView.addSubview(self.favoriteButton)
+        NSLayoutConstraint.activate([
+            self.favoriteButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -10.0),
+            self.favoriteButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10.0),
+            self.favoriteButton.heightAnchor.constraint(equalToConstant: 30.0),
+            self.favoriteButton.widthAnchor.constraint(equalToConstant: 30.0),
+        ])
         
         let infoStack = UIStackView(arrangedSubviews: [self.titleLabel, self.subtitleLabel])
         infoStack.axis = .vertical
@@ -50,7 +73,7 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         infoStack.alignment = .fill
         infoStack.spacing = 0
         
-        let mainStack = UIStackView(arrangedSubviews: [self.imageView, infoStack])
+        let mainStack = UIStackView(arrangedSubviews: [containerView, infoStack])
         mainStack.axis = .vertical
         mainStack.distribution = .fill
         mainStack.alignment = .fill
@@ -58,6 +81,7 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         
         super.init(frame: frame)
         
+        self.favoriteButton.addTarget(self, action: #selector(self.favoriteButtonAction), for: .touchUpInside)
         self.contentView.addPinnedSubview(mainStack)
     }
     
@@ -70,8 +94,25 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         self.clear()
     }
     
+    
+    private func updateState(for button: UIButton, asFavorite favorite: Bool) {
+        let fillImage = UIImage(systemName: "heart.fill")?.withRenderingMode(.alwaysTemplate)
+        let normalImage = UIImage(systemName: "heart")?.withRenderingMode(.alwaysTemplate)
+        
+        if favorite {
+            button.setImage(fillImage, for: .normal)
+            button.setImage(normalImage, for: .selected)
+            button.setImage(normalImage, for: .highlighted)
+        } else {
+            button.setImage(normalImage, for: .normal)
+            button.setImage(fillImage, for: .selected)
+            button.setImage(fillImage, for: .highlighted)
+        }
+    }
+    
     //MARK: Configuration
-    func configure(viewData: ViewData, isLargeSection: Bool, imageLoader: ImageLoadingService, imageCache: RemoteImageCaching, session: Session, theme: Theme) {
+    func configure(viewData: ViewData, isLargeSection: Bool, imageLoader: ImageLoadingService, imageCache: RemoteImageCaching, session: Session, theme: Theme, favoriteAction: @escaping () async -> Bool) {
+        self.favoriteAction = favoriteAction
         self.titleLabel.text = viewData.title
         self.subtitleLabel.text = viewData.subtitle
         
@@ -82,6 +123,12 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         
         self.imageView.image = nil
         self.imageView.backgroundColor = theme.imagePlaceholderBackgroundColor
+        
+        self.favoriteButton.tintColor = theme.primaryNavBarTintColor
+        self.favoriteButton.backgroundColor = theme.primaryNavBarBackgroundColor
+        self.favoriteButton.isHidden = !viewData.showFavorite
+        self.favoriteButton.layer.cornerRadius = isLargeSection ? 16.0 : 12.0
+        self.updateState(for: self.favoriteButton, asFavorite: viewData.isFavorite)
         
         if let image = imageCache.imageForURL(imageUrl) {
             self.imageView.transition(to: image, animated: false)
@@ -96,7 +143,12 @@ class MWImageCollectionViewCell: UICollectionViewCell {
         }
     }
     
+    @objc private func favoriteButtonAction() {
+        Task { await self.favoriteAction() }
+    }
+    
     private func clear() {
+        self.favoriteAction = { false }
         self.titleLabel.text = nil
         self.subtitleLabel.text = nil
         


### PR DESCRIPTION
### Task

[[iOS] [Android] [Rails] Allow users to favourite content](https://3.basecamp.com/5245563/buckets/26112855/todos/6171847580)

### Feature/Issue

Allow the Grid to show an action with an icon for each item.

### Implementation

The following properties were added to the GridItem to be used by the Network spec:

- actionURL: URL that will be called when the button is pressed
- actionMethod: The HTTP verb to be used when performing the request
- actionSFSymbolName: Name of the SF Symbol that will be used in the button

If any of these properties is missing no action is shown.

At the end of the action, there is a call to the server to refresh the list. This is useful to create a "toggle" state in the action, like favorite (see video). In case of error, the current state items are shown.

### Demonstration

https://github.com/FutureWorkshops/MWContentDisplayPlugin-iOS/assets/2117340/393dd272-396d-4242-9b19-c72ec6e79a4b
